### PR TITLE
Add language header to API requests

### DIFF
--- a/src/api/callApi.ts
+++ b/src/api/callApi.ts
@@ -1,5 +1,6 @@
 import { call, Effect, select } from 'redux-saga/effects';
 import { getApiToken } from '../auth/selectors';
+import i18n, { defaultLanguage } from '../i18n';
 
 export interface ApiCallResult {
   response: Response;
@@ -16,6 +17,11 @@ function* callApi(
   if (apiToken) {
     request.headers.set('Authorization', `Bearer ${apiToken}`);
   }
+
+  request.headers.set(
+    'Accept-Language',
+    `${i18n.language},${defaultLanguage};q=0.5`
+  );
 
   if (
     request.method === 'PATCH' ||

--- a/src/topNavigation/topNavigation.tsx
+++ b/src/topNavigation/topNavigation.tsx
@@ -56,6 +56,12 @@ const TopNavigation = ({ openLoginModal }: TopNavigationProps): JSX.Element => {
   );
   const matchAreaSearch = useMatch(getRouteById(AppRoutes.AREA_SEARCH));
 
+  const changeLanguage = (language: Language) => {
+    i18n.changeLanguage(language).then(() => {
+      document.location.reload();
+    });
+  };
+
   return (
     <Navigation
       menuToggleAriaLabel={t('topNavigation.menuLabel', 'Menu')}
@@ -101,17 +107,17 @@ const TopNavigation = ({ openLoginModal }: TopNavigationProps): JSX.Element => {
           <Navigation.Item
             label="Suomeksi"
             lang={Language.FI}
-            onClick={() => i18n.changeLanguage(Language.FI)}
+            onClick={() => changeLanguage(Language.FI)}
           />
           <Navigation.Item
             label="På svenska"
             lang={Language.SV}
-            onClick={() => i18n.changeLanguage(Language.SV)}
+            onClick={() => changeLanguage(Language.SV)}
           />
           <Navigation.Item
             label="In English"
             lang={Language.EN}
-            onClick={() => i18n.changeLanguage(Language.EN)}
+            onClick={() => changeLanguage(Language.EN)}
           />
         </Navigation.LanguageSelector>
       </Navigation.Actions>


### PR DESCRIPTION
Since the store might contain data in the previously selected language, the page is refreshed when the language is changed.