### PR TITLE
Added filtering (search_class=plot_search) when fetching plot searches

### DIFF
--- a/src/plotSearch/actions.ts
+++ b/src/plotSearch/actions.ts
@@ -16,8 +16,9 @@ import {
 } from './types';
 import { ApiAttributes } from '../api/types';
 
-export const fetchPlotSearches = (): Action<string> =>
-  createAction(FETCH_PLOT_SEARCHES)();
+export const fetchPlotSearches = (payload?: {
+  params: Record<string, string>;
+}): Action<string> => createAction(FETCH_PLOT_SEARCHES)(payload);
 
 export const receivePlotSearches = (
   payload: Array<PlotSearch>

--- a/src/plotSearchAndCompetitionsPage/plotSearchAndCompetitionsPage.tsx
+++ b/src/plotSearchAndCompetitionsPage/plotSearchAndCompetitionsPage.tsx
@@ -31,7 +31,7 @@ interface State {
 }
 
 interface Props {
-  fetchPlotSearches: () => void;
+  fetchPlotSearches: (payload?: { params: Record<string, string> }) => void;
   fetchPlotSearchAttributes: () => void;
   fetchPlotSearchTypes: () => void;
   isFetchingPlotSearches: boolean;
@@ -75,7 +75,7 @@ const PlotSearchAndCompetitionsPage = (props: Props): JSX.Element => {
   const [isSidebarOpen, setSidebarOpen] = useState<boolean>(true);
 
   useEffect(() => {
-    fetchPlotSearches();
+    fetchPlotSearches({ params: { search_class: 'plot_search' } });
     fetchPlotSearchAttributes();
     fetchPlotSearchTypes();
   }, []);


### PR DESCRIPTION
Edited fetchPlotSearches action to take params as payload (optional). This is used in plotsearch and competitions -page.

This change was requested by Niko Vuorinen.