### PR TITLE
Fix inability to add a new applicant to a plot application

### DIFF
--- a/src/application/components/applicationFormSubsection.tsx
+++ b/src/application/components/applicationFormSubsection.tsx
@@ -280,6 +280,7 @@ interface ApplicationFormSubsectionFieldArrayProps {
   section: FormSection;
   headerTag: React.ElementType;
   flavor?: ApplicationFormTopLevelSectionFlavor;
+  path: Array<string>;
 }
 
 interface ApplicationFormSubsectionFieldArrayInnerProps {
@@ -296,6 +297,7 @@ const ApplicationFormSubsectionFieldArray = connect(null, {
     headerTag: HeaderTag,
     flavor,
     removeFavouriteTarget,
+    path,
   }: WrappedFieldArrayProps<ApplicationFormNode> &
     ApplicationFormSubsectionFieldArrayProps &
     ApplicationFormSubsectionFieldArrayInnerProps): JSX.Element => {
@@ -386,7 +388,13 @@ const ApplicationFormSubsectionFieldArray = connect(null, {
           <Button
             className="ApplicationFormSubsectionFieldArray__add-button"
             onClick={() =>
-              fields.push(getSectionTemplate(section.identifier, formName))
+              fields.push(
+                getSectionTemplate(
+                  section.identifier,
+                  formName,
+                  path.slice(0, -1).join('.')
+                )
+              )
             }
             variant="supplementary"
             iconLeft={<IconPlusCircle />}
@@ -455,7 +463,7 @@ const ApplicationFormSubsection = ({
         >
           name={pathName}
           component={ApplicationFormSubsectionFieldArray}
-          props={{ section, headerTag: HeaderTag, formName }}
+          props={{ section, headerTag: HeaderTag, formName, path }}
           flavor={flavor}
         />
       ) : (

--- a/src/application/helpers.ts
+++ b/src/application/helpers.ts
@@ -162,7 +162,7 @@ export const getSectionTemplate = (
   const state = store.getState();
   const templates = formValueSelector(formName)(
     state,
-    `${path !== '' && path + '.'}sectionTemplates`
+    `${path !== '' ? path + '.' : ''}sectionTemplates`
   );
 
   return templates[identifier] || {};


### PR DESCRIPTION
No idea how it could've worked previously, as I'm quite sure I made test applications with multiple applicants without it breaking at that time, but looking at the code it shouldn't have. (With an empty subpath, the key to query the form state was "falsesectionTemplates".)