### PR TITLE
Fixed ApplicantType enums to be similar to backend regardless the selected language

### DIFF
--- a/src/application/types.ts
+++ b/src/application/types.ts
@@ -240,10 +240,10 @@ export enum ApplicationFormTopLevelSectionFlavor {
 }
 
 export enum ApplicantTypes {
-  PERSON = 'Person',
-  COMPANY = 'Company',
-  BOTH = 'Both',
-  UNKNOWN = 'Unknown',
+  PERSON = 'person',
+  COMPANY = 'company',
+  BOTH = 'both',
+  UNKNOWN = 'unknown',
 
   // UI only states
   UNSELECTED = 'unselected',


### PR DESCRIPTION
Backend now returns the enumvalue instead of translated string, so these are always lowercase/snake_case