### PR TITLE
Fix the ongoing searches filter

### DIFF
--- a/src/mapSearch/mapSearchPage.tsx
+++ b/src/mapSearch/mapSearchPage.tsx
@@ -11,14 +11,12 @@ import BlockLoader from '../loader/blockLoader';
 import {
   fetchPlotSearchAttributes,
   fetchPlotSearches,
-  fetchPlotSearchStages,
   fetchPlotSearchTypes,
 } from '../plotSearch/actions';
 
 import { ApiAttributes } from '../api/types';
 import {
   PlotSearch,
-  PlotSearchStage,
   PlotSearchSubtype,
   PlotSearchTarget,
   PlotSearchType,
@@ -36,7 +34,6 @@ interface State {
   plotSearches: Array<PlotSearch>;
   plotSearchAttributes: ApiAttributes;
   plotSearchTypes: Array<PlotSearchType>;
-  plotSearchStages: Array<PlotSearchStage>;
   favourite: Favourite;
 }
 
@@ -45,7 +42,6 @@ interface Props {
   fetchPlotSearches: (payload?: { params: Record<string, string> }) => void;
   fetchPlotSearchAttributes: () => void;
   fetchPlotSearchTypes: () => void;
-  fetchPlotSearchStages: () => void;
   isFetchingPlotSearches: boolean;
   isFetchingPlotSearchAttributes: boolean;
   isFetchingPlotSearchTypes: boolean;
@@ -53,7 +49,6 @@ interface Props {
   plotSearches: Array<PlotSearch>;
   plotSearchAttributes: ApiAttributes;
   plotSearchTypes: Array<PlotSearchType>;
-  plotSearchStages: Array<PlotSearchStage>;
   favourite: Favourite;
 }
 
@@ -76,13 +71,11 @@ const MapSearchPage = (props: Props): JSX.Element => {
     fetchPlotSearches,
     fetchPlotSearchAttributes,
     fetchPlotSearchTypes,
-    fetchPlotSearchStages,
     isFetchingPlotSearches,
     isFetchingPlotSearchAttributes,
     isFetchingPlotSearchTypes,
     isFetchingPlotSearchStages,
     plotSearchTypes,
-    plotSearchStages,
     plotSearches,
     favourite,
   } = props;
@@ -139,14 +132,8 @@ const MapSearchPage = (props: Props): JSX.Element => {
   useEffect(() => {
     fetchPlotSearchAttributes();
     fetchPlotSearchTypes();
-    fetchPlotSearchStages();
+    fetchPlotSearches({ params: { search_class: searchClass } });
   }, []);
-
-  useEffect(() => {
-    if (!isFetchingPlotSearchStages && plotSearchStages.length > 0) {
-      fetchPlotSearches({ params: { search_class: searchClass } });
-    }
-  }, [isFetchingPlotSearchStages]);
 
   useEffect(() => {
     let newOptions = [...(plotSearchTypes || [])];
@@ -253,7 +240,6 @@ const mapStateToProps = (state: RootState): State => ({
     state.plotSearch.isFetchingPlotSearchAttributes,
   isFetchingPlotSearchTypes: state.plotSearch.isFetchingPlotSearchTypes,
   isFetchingPlotSearchStages: state.plotSearch.isFetchingPlotSearchStages,
-  plotSearchStages: state.plotSearch.plotSearchStages,
   favourite: state.favourite.favourite,
 });
 
@@ -261,5 +247,4 @@ export default connect(mapStateToProps, {
   fetchPlotSearches,
   fetchPlotSearchAttributes,
   fetchPlotSearchTypes,
-  fetchPlotSearchStages,
 })(MapSearchPage);

--- a/src/plotSearch/saga.ts
+++ b/src/plotSearch/saga.ts
@@ -6,6 +6,7 @@ import {
   put,
   select,
   takeLatest,
+  take,
 } from 'redux-saga/effects';
 import {
   fetchPlotSearchAttributesRequest,
@@ -22,8 +23,11 @@ import {
   PlotSearchFromBackend,
   PlotSearchStage,
   FETCH_PLOT_SEARCH_STAGES,
+  PLOT_SEARCH_STAGES_NOT_FOUND,
+  RECEIVE_PLOT_SEARCH_STAGES,
 } from './types';
 import {
+  fetchPlotSearchStages,
   plotSearchAttributesNotFound,
   plotSearchesNotFound,
   plotSearchStagesNotFound,
@@ -43,9 +47,19 @@ function* fetchPlotSearchesSaga({
   payload,
 }: FetchPlotSearchesAction): Generator<Effect, void, never> {
   try {
-    const stages: Array<PlotSearchStage> = yield select(
+    let stages: Array<PlotSearchStage> = yield select(
       (state: RootState) => state.plotSearch.plotSearchStages
     );
+
+    if (!stages.length) {
+      yield put(fetchPlotSearchStages());
+      yield take([RECEIVE_PLOT_SEARCH_STAGES, PLOT_SEARCH_STAGES_NOT_FOUND]);
+
+      stages = yield select(
+        (state: RootState) => state.plotSearch.plotSearchStages
+      );
+    }
+
     const ongoingId = stages.find((stage) => stage.stage === 'in_action')?.id;
 
     if (!ongoingId) {


### PR DESCRIPTION
The search states were needed on a few other pages as well, and since them being present is always required as a prerequisite for fetching plot searches, it makes sense to add that into the plot search saga directly.

In particular, this was messing up the usual application submission flow because after log-in the states weren't in the state anymore yet the application flow itself assumed it was. Instead of adding the same wait-until-states-fetched -> fetch-searches flow, I thought this makes it more concise and robust.