### PR TITLE
Fix issue of fetching favourite while updating token

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -68,9 +68,6 @@ const App = ({
           ),
         );
       }
-      if (!isFetchingFavourite) {
-        fetchFavourite();
-      }
     } else {
       if (tokenRefreshTimeout) {
         clearTimeout(tokenRefreshTimeout);
@@ -80,6 +77,12 @@ const App = ({
       }
     }
   }, [user, tokenOutdated, isFetchingToken]);
+
+  useEffect(() => {
+    if (!isFetchingFavourite && !isFetchingToken && user) {
+      fetchFavourite();
+    }
+  }, [isFetchingToken, user]);
 
   return (
     <div className="App">


### PR DESCRIPTION
Observed behavior previously was that when token is to be refreshed the useEffect  is triggered when tokenOutdated. The same useEffect also happens to always run fetchFavourite whenever favourite is not being fetched.
This lead to fetchFavourite being run unsuccesfully on every token refresh, while fetchFavourite used the old token and never succeeded.