### PR TITLE
WIP: Update Area Specs with PUT

### DIFF
--- a/src/application/components/applicationFormSubsection.tsx
+++ b/src/application/components/applicationFormSubsection.tsx
@@ -160,6 +160,7 @@ const ApplicationFormSubsectionFields = connect(
 
       useEffect(() => {
         // set default value if exists and current value is empty
+        console.log('applicationFormSubsection useEffect', field);
         if (
           field.default_value !== null &&
           !getValue(`${identifier}.fields.${field.identifier}.value`)
@@ -281,7 +282,7 @@ const ApplicationFormSubsectionFields = connect(
 
   const checkSpecialValues = (
     field: FormField,
-    newValues: Partial<ApplicationField>
+    newValues: Partial<ApplicationField>,
   ) => {
     if (
       section.identifier === APPLICANT_SECTION_IDENTIFIER &&
@@ -291,7 +292,7 @@ const ApplicationFormSubsectionFields = connect(
       change(
         formName,
         `${identifier}.metadata.applicantType`,
-        valueToApplicantType(newValues.value as string)
+        valueToApplicantType(newValues.value as string),
       );
     }
   };
@@ -494,6 +495,17 @@ const ApplicationFormSubsection = ({
   const isArray = section.add_new_allowed;
   const pathName = [...path, section.identifier].join('.');
 
+  console.log('ApplicationFormSubsection formName', formName);
+  console.log('ApplicationFormSubsection path', path);
+  console.log('ApplicationFormSubsection section', section);
+  console.log('ApplicationFormSubsection headerTag', HeaderTag);
+  console.log('ApplicationFormSubsection flavor ', flavor);
+  console.log(
+    'ApplicationFormSubsection parentApplicantType',
+    parentApplicantType,
+  );
+  console.log('ApplicationFormSubsection isSaveClicked', isSaveClicked);
+
   return (
     <div
       className={classNames(
@@ -501,6 +513,7 @@ const ApplicationFormSubsection = ({
         `ApplicationFormSubsection--${flavor}`,
       )}
     >
+      <p>ApplicationFormSubsection</p>
       {isArray ? (
         <FieldArray<
           ApplicationFormSubsectionFieldArrayProps,

--- a/src/areaSearch/actions.ts
+++ b/src/areaSearch/actions.ts
@@ -20,7 +20,6 @@ import {
   AREA_SEARCH_ATTACHMENT_SUBMISSION_FAILED,
   RECEIVE_AREA_SEARCH_ATTACHMENT_SAVED,
   INITIALIZE_AREA_SEARCH_ATTACHMENTS,
-  SET_NEXT_AREA_SEARCH_APPLICATION_STEP,
 } from './types';
 
 export const submitAreaSearch = (
@@ -37,9 +36,6 @@ export const submitAreaSearchAttachment = (payload: {
 
 export const initializeAreaSearchAttachments = (): Action<string> =>
   createAction(INITIALIZE_AREA_SEARCH_ATTACHMENTS)();
-
-export const setNextStep = (): Action<string> =>
-  createAction(SET_NEXT_AREA_SEARCH_APPLICATION_STEP)();
 
 export const areaSearchAttachmentSubmissionFailed = (
   payload: unknown,

--- a/src/areaSearch/actions.ts
+++ b/src/areaSearch/actions.ts
@@ -20,10 +20,11 @@ import {
   AREA_SEARCH_ATTACHMENT_SUBMISSION_FAILED,
   RECEIVE_AREA_SEARCH_ATTACHMENT_SAVED,
   INITIALIZE_AREA_SEARCH_ATTACHMENTS,
+  SET_NEXT_AREA_SEARCH_APPLICATION_STEP,
 } from './types';
 
 export const submitAreaSearch = (
-  payload: AreaSearchSubmission
+  payload: AreaSearchSubmission,
 ): Action<string> => createAction(SUBMIT_AREA_SEARCH)(payload);
 
 export const submitAreaSearchAttachment = (payload: {
@@ -37,13 +38,16 @@ export const submitAreaSearchAttachment = (payload: {
 export const initializeAreaSearchAttachments = (): Action<string> =>
   createAction(INITIALIZE_AREA_SEARCH_ATTACHMENTS)();
 
+export const setNextStep = (): Action<string> =>
+  createAction(SET_NEXT_AREA_SEARCH_APPLICATION_STEP)();
+
 export const areaSearchAttachmentSubmissionFailed = (
-  payload: unknown
+  payload: unknown,
 ): Action<string> =>
   createAction(AREA_SEARCH_ATTACHMENT_SUBMISSION_FAILED)(payload);
 
 export const receiveAreaSearchAttachmentSaved = (
-  payload: File
+  payload: File,
 ): Action<string> =>
   createAction(RECEIVE_AREA_SEARCH_ATTACHMENT_SAVED)(payload);
 
@@ -54,16 +58,16 @@ export const areaSearchSubmissionFailed = (payload: unknown): Action<string> =>
   createAction(AREA_SEARCH_SUBMISSION_FAILED)(payload);
 
 export const submitAreaSearchApplication = (
-  payload: AreaSearchApplicationSubmission
+  payload: AreaSearchApplicationSubmission,
 ): Action<string> => createAction(SUBMIT_AREA_SEARCH_APPLICATION)(payload);
 
 export const receiveAreaSearchApplicationSaved = (
-  payload: AreaSearch
+  payload: AreaSearch,
 ): Action<string> =>
   createAction(RECEIVE_AREA_SEARCH_APPLICATION_SAVED)(payload);
 
 export const areaSearchApplicationSubmissionFailed = (
-  payload: unknown
+  payload: unknown,
 ): Action<string> =>
   createAction(AREA_SEARCH_APPLICATION_SUBMISSION_FAILED)(payload);
 
@@ -71,7 +75,7 @@ export const fetchIntendedUses = (): Action<string> =>
   createAction(FETCH_INTENDED_USES)();
 
 export const receiveIntendedUses = (
-  payload: Array<IntendedUse>
+  payload: Array<IntendedUse>,
 ): Action<string> => createAction(RECEIVE_INTENDED_USES)(payload);
 
 export const intendedUsesNotFound = (): Action<string> =>

--- a/src/areaSearch/areaSearchApplicationPage.tsx
+++ b/src/areaSearch/areaSearchApplicationPage.tsx
@@ -1,10 +1,10 @@
-import { useState } from 'react';
+import { useEffect, useReducer, useState } from 'react';
 import { Button } from 'hds-react';
 import { Col, Container, Row } from 'react-grid-system';
 import { Helmet } from 'react-helmet';
 import { useTranslation } from 'react-i18next';
 import { connect } from 'react-redux';
-import { isValid } from 'redux-form';
+import { isValid, setSubmitSucceeded } from 'redux-form';
 
 import MainContentElement from '../a11y/MainContentElement';
 import AuthDependentContent from '../auth/components/authDependentContent';
@@ -22,6 +22,7 @@ interface State {
   lastSubmission: AreaSearch | null;
   isSubmittingAreaSearch: boolean;
   isFormValid: boolean;
+  currentStep: number;
 }
 
 interface Props extends State {
@@ -33,9 +34,11 @@ const AreaSearchApplicationPage = ({
   isSubmittingAreaSearch,
   lastSubmission,
   isFormValid,
+  currentStep,
 }: Props): JSX.Element => {
   const { t } = useTranslation();
   const [isSaveClicked, setSaveClicked] = useState<boolean>(false);
+  const [_, forceUpdate] = useReducer((x) => x + 1, 0);
 
   const openPreview = () => {
     setSaveClicked(true);
@@ -45,7 +48,16 @@ const AreaSearchApplicationPage = ({
     }
   };
 
-  const renderApplicationForm = (loading: boolean, loggedIn: boolean) => {
+  useEffect(() => {
+    forceUpdate();
+  }, [currentStep]);
+
+  const renderApplicationForm = (
+    lastSubmission: AreaSearch,
+    loading: boolean,
+    loggedIn: boolean,
+  ) => {
+    console.log('HEP');
     if (loading || isSubmittingAreaSearch) {
       return <BlockLoader />;
     } else if (loggedIn) {
@@ -111,6 +123,7 @@ const AreaSearchApplicationPage = ({
       <ScrollToTop />
       <AuthDependentContent>
         {(loading, loggedIn) => {
+          console.log('auth lastsub', lastSubmission);
           return (
             <>
               <MainContentElement className="ApplicationPage">
@@ -133,7 +146,8 @@ const AreaSearchApplicationPage = ({
                   </h1>
                   {lastSubmission && <AreaSearchTargetSummary />}
                   <div className="ApplicationPage__form-container">
-                    {renderApplicationForm(loading, loggedIn)}
+                    {lastSubmission &&
+                      renderApplicationForm(lastSubmission, loading, loggedIn)}
                   </div>
                 </Container>
               </MainContentElement>
@@ -150,6 +164,7 @@ export default connect(
     lastSubmission: state.areaSearch.lastSubmission,
     isSubmittingAreaSearch: state.areaSearch.isSubmittingAreaSearch,
     isFormValid: isValid(AREA_SEARCH_FORM_NAME)(state),
+    currentStep: state.areaSearch.currentStep,
   }),
   {
     openLoginModal,

--- a/src/areaSearch/areaSearchApplicationPage.tsx
+++ b/src/areaSearch/areaSearchApplicationPage.tsx
@@ -26,7 +26,6 @@ interface State {
 
 interface Props extends State {
   openLoginModal: () => void;
-  setNextStep: any;
 }
 
 const AreaSearchApplicationPage = ({
@@ -34,7 +33,6 @@ const AreaSearchApplicationPage = ({
   isSubmittingAreaSearch,
   lastSubmission,
   isFormValid,
-  setNextStep,
 }: Props): JSX.Element => {
   const { t } = useTranslation();
   const [isSaveClicked, setSaveClicked] = useState<boolean>(false);
@@ -43,7 +41,7 @@ const AreaSearchApplicationPage = ({
     setSaveClicked(true);
 
     if (isFormValid) {
-      setNextStep();
+      // setNextStep();
     }
   };
 

--- a/src/areaSearch/areaSearchApplicationPreview.tsx
+++ b/src/areaSearch/areaSearchApplicationPreview.tsx
@@ -42,8 +42,6 @@ interface State {
 interface Props extends State {
   submitApplication: (data: AreaSearchApplicationSubmission) => void;
   isSubmitting?: boolean;
-  setNextStep: Function;
-  setPreviousStep: Function;
 }
 
 const AreaSearchApplicationPreview = ({
@@ -53,8 +51,6 @@ const AreaSearchApplicationPreview = ({
   lastError,
   isSubmitting,
   submittedAnswerId,
-  setNextStep,
-  setPreviousStep,
 }: Props): JSX.Element => {
   const { t } = useTranslation();
 
@@ -65,7 +61,7 @@ const AreaSearchApplicationPreview = ({
 
   useEffect(() => {
     if (submittedAnswerId !== previousAnswerId) {
-      setNextStep();
+      // setNextStep();
     }
   }, [submittedAnswerId]);
 
@@ -100,7 +96,7 @@ const AreaSearchApplicationPreview = ({
         />
       ));
     } else {
-      setPreviousStep();
+      // setPreviousStep();
     }
   };
 
@@ -142,7 +138,7 @@ const AreaSearchApplicationPreview = ({
                   {renderSectionPreviewsOrGoBack(loggedIn)}
                   <Button
                     variant="secondary"
-                    onClick={() => setPreviousStep()}
+                    onClick={() => console.log('setPreviousStep')}
                     disabled={isSubmitting}
                     className="ApplicationPreviewPage__submission-button"
                   >

--- a/src/areaSearch/areaSearchApplicationRootPage.tsx
+++ b/src/areaSearch/areaSearchApplicationRootPage.tsx
@@ -27,6 +27,7 @@ import ScrollToTop from '../common/ScrollToTop';
 interface State {
   areaSearchForm: null;
   lastSubmission: AreaSearch | null;
+  currentStep: number;
 }
 
 interface Step {
@@ -45,16 +46,17 @@ const AreaSearchApplicationRootPage = ({
   initializeForm,
   fetchFormAttributes,
   valid,
+  currentStep,
 }: Props & InjectedFormProps<unknown, Props>): JSX.Element => {
-  const [currentStep, setCurrentStep] = useState<number>(0);
+  // const [currentStep, setCurrentStep] = useState<number>(0);
 
-  const setNextStep = () => {
-    setCurrentStep(currentStep + 1);
-  };
+  // const setNextStep = () => {
+  //   setCurrentStep(currentStep + 1);
+  // };
 
-  const setPreviousStep = () => {
-    setCurrentStep(currentStep - 1);
-  };
+  // const setPreviousStep = () => {
+  //   setCurrentStep(currentStep - 1);
+  // };
 
   const [steps, setSteps] = useState<Step[]>([
     {
@@ -78,16 +80,11 @@ const AreaSearchApplicationRootPage = ({
   const renderCurrentStep = () => {
     switch (steps[currentStep].label) {
       case 'Alueen valinta':
-        return <AreaSearchSpecsPage valid={valid} setNextStep={setNextStep} />;
+        return <AreaSearchSpecsPage valid={valid} />;
       case 'Hakemuksen täyttö':
-        return <AreaSearchApplicationPage setNextStep={setNextStep} />;
+        return <AreaSearchApplicationPage />;
       case 'Esikatselu':
-        return (
-          <AreaSearchApplicationPreview
-            setPreviousStep={setPreviousStep}
-            setNextStep={setNextStep}
-          />
-        );
+        return <AreaSearchApplicationPreview />;
       case 'Lähetys':
         return <AreaSearchApplicationSuccessPage />;
       default:
@@ -150,8 +147,8 @@ const AreaSearchApplicationRootPage = ({
                     steps={steps}
                     language="en"
                     selectedStep={currentStep}
-                    onStepClick={(_, nextPageIndex) =>
-                      setCurrentStep(nextPageIndex)
+                    onStepClick={() =>
+                      console.log('setCurrentStep(nextPageIndex')
                     }
                   />
                 </div>
@@ -185,6 +182,7 @@ export default connect(
   (state: RootState): State => ({
     areaSearchForm: null,
     lastSubmission: state.areaSearch.lastSubmission,
+    currentStep: state.areaSearch.currentStep,
   }),
   {
     openLoginModal,

--- a/src/areaSearch/areaSearchApplicationRootPage.tsx
+++ b/src/areaSearch/areaSearchApplicationRootPage.tsx
@@ -130,6 +130,8 @@ const AreaSearchApplicationRootPage = ({
     updateStepAvailability();
   }, [valid, currentStep]);
 
+  console.log('ROOT HEP');
+
   return (
     <MainContentElement className="AreaSearchSpecsPage">
       <Helmet>

--- a/src/areaSearch/areaSearchSpecsPage.tsx
+++ b/src/areaSearch/areaSearchSpecsPage.tsx
@@ -52,6 +52,7 @@ interface State {
   intendedUses: Array<IntendedUse> | null;
   lastSubmission: AreaSearch | null;
   lastSubmissionId: number;
+  currentStep: number;
   errors: FormErrors;
   applicationFormTemplate: ApplicationFormRoot;
 }
@@ -89,6 +90,7 @@ const AreaSearchSpecsPage = ({
   intendedUses,
   lastSubmission,
   lastSubmissionId,
+  currentStep,
   lastSubmissionError,
   applicationFormTemplate,
   change,
@@ -159,12 +161,12 @@ const AreaSearchSpecsPage = ({
     }
   }, []);
 
-  // useEffect(() => {
-  //   if (lastSubmissionId > prevSubmissionIdRef.current) {
-  //     prevSubmissionIdRef.current = lastSubmissionId;
-  //     setSubmitSucceeded(AREA_SEARCH_FORM_NAME);
-  //   }
-  // }, [lastSubmissionId]);
+  useEffect(() => {
+    if (lastSubmissionId > prevSubmissionIdRef.current) {
+      prevSubmissionIdRef.current = lastSubmissionId;
+      setSubmitSucceeded(AREA_SEARCH_FORM_NAME);
+    }
+  }, [lastSubmissionId]);
 
   return (
     <>
@@ -452,6 +454,7 @@ export default connect(
     lastSubmission: state.areaSearch.lastSubmission,
     lastSubmissionId: state.areaSearch.lastSubmissionId,
     lastSubmissionError: state.areaSearch.lastError,
+    currentStep: state.areaSearch.currentStep,
     errors: getFormSyncErrors(AREA_SEARCH_FORM_NAME)(state),
     applicationFormTemplate: getInitialAreaSearchApplicationForm(state),
   }),

--- a/src/areaSearch/areaSearchSpecsPage.tsx
+++ b/src/areaSearch/areaSearchSpecsPage.tsx
@@ -159,14 +159,12 @@ const AreaSearchSpecsPage = ({
     }
   }, []);
 
-  useEffect(() => {
-    if (lastSubmissionId > prevSubmissionIdRef.current) {
-      prevSubmissionIdRef.current = lastSubmissionId;
-      setSubmitSucceeded(AREA_SEARCH_FORM_NAME);
-      // setNextStep();
-    }
-    console.log('HEP');
-  }, [lastSubmissionId, lastSubmission]);
+  // useEffect(() => {
+  //   if (lastSubmissionId > prevSubmissionIdRef.current) {
+  //     prevSubmissionIdRef.current = lastSubmissionId;
+  //     setSubmitSucceeded(AREA_SEARCH_FORM_NAME);
+  //   }
+  // }, [lastSubmissionId]);
 
   return (
     <>

--- a/src/areaSearch/areaSearchSpecsPage.tsx
+++ b/src/areaSearch/areaSearchSpecsPage.tsx
@@ -32,7 +32,7 @@ import {
   requiredValidatorGenerator,
 } from '../form/validators';
 import { RootState } from '../root/rootReducer';
-import { AREA_SEARCH_FORM_NAME, IntendedUse } from './types';
+import { AREA_SEARCH_FORM_NAME, AreaSearch, IntendedUse } from './types';
 import {
   fetchIntendedUses,
   initializeAreaSearchAttachments,
@@ -50,6 +50,7 @@ interface State {
   startDate?: string;
   endDate?: string;
   intendedUses: Array<IntendedUse> | null;
+  lastSubmission: AreaSearch | null;
   lastSubmissionId: number;
   errors: FormErrors;
   applicationFormTemplate: ApplicationFormRoot;
@@ -86,6 +87,7 @@ const AreaSearchSpecsPage = ({
   setSubmitSucceeded,
   fetchIntendedUses,
   intendedUses,
+  lastSubmission,
   lastSubmissionId,
   lastSubmissionError,
   applicationFormTemplate,
@@ -155,12 +157,16 @@ const AreaSearchSpecsPage = ({
     if (!prevSubmissionIdRef.current) {
       change(AREA_SEARCH_FORM_NAME, 'form', applicationFormTemplate, true);
     }
+  }, []);
+
+  useEffect(() => {
     if (lastSubmissionId > prevSubmissionIdRef.current) {
       prevSubmissionIdRef.current = lastSubmissionId;
       setSubmitSucceeded(AREA_SEARCH_FORM_NAME);
       // setNextStep();
     }
-  }, [lastSubmissionId]);
+    console.log('HEP');
+  }, [lastSubmissionId, lastSubmission]);
 
   return (
     <>
@@ -445,6 +451,7 @@ export default connect(
     endDate: selector(state, 'search.end_date'),
     intendedUses: state.areaSearch.intendedUses,
     isSubmittingAreaSearch: state.areaSearch.isSubmittingAreaSearch,
+    lastSubmission: state.areaSearch.lastSubmission,
     lastSubmissionId: state.areaSearch.lastSubmissionId,
     lastSubmissionError: state.areaSearch.lastError,
     errors: getFormSyncErrors(AREA_SEARCH_FORM_NAME)(state),

--- a/src/areaSearch/areaSearchSpecsPage.tsx
+++ b/src/areaSearch/areaSearchSpecsPage.tsx
@@ -68,7 +68,6 @@ interface OwnProps {
   valid: boolean;
   touch(...field: string[]): void;
   lastSubmissionError: unknown;
-  setNextStep: any;
 }
 
 type Props = OwnProps & State;
@@ -91,7 +90,6 @@ const AreaSearchSpecsPage = ({
   lastSubmissionError,
   applicationFormTemplate,
   change,
-  setNextStep,
 }: Props): JSX.Element => {
   const { t } = useTranslation();
 
@@ -160,7 +158,7 @@ const AreaSearchSpecsPage = ({
     if (lastSubmissionId > prevSubmissionIdRef.current) {
       prevSubmissionIdRef.current = lastSubmissionId;
       setSubmitSucceeded(AREA_SEARCH_FORM_NAME);
-      setNextStep();
+      // setNextStep();
     }
   }, [lastSubmissionId]);
 
@@ -187,9 +185,12 @@ const AreaSearchSpecsPage = ({
               if (valid) {
                 startSubmit(AREA_SEARCH_FORM_NAME);
                 setHasSubmitErrors(false);
-                submitAreaSearch(
-                  prepareAreaSearchSubmission(files['search.attachments']),
-                );
+                let currentAreaSearchId = lastSubmissionId && lastSubmissionId;
+                const submitParams = {
+                  ...prepareAreaSearchSubmission(files['search.attachments']),
+                  id: currentAreaSearchId,
+                };
+                submitAreaSearch(submitParams);
               } else {
                 if (touch) {
                   touch(

--- a/src/areaSearch/components/applicationForm.tsx
+++ b/src/areaSearch/components/applicationForm.tsx
@@ -22,6 +22,8 @@ const ApplicationForm = ({
     (section) => section.identifier === APPLICANT_SECTION_IDENTIFIER,
   );
 
+  console.log('applicant section', applicantSection);
+
   const confirmationSection = baseForm.sections.find(
     (section) => section.identifier === CONFIRMATION_SECTION_IDENTIFIER,
   );
@@ -36,17 +38,20 @@ const ApplicationForm = ({
   return (
     <form className="AreaSearchApplicationForm">
       {applicantSection && (
-        <div className="AreaSearchApplicationForm__section">
-          <ApplicationFormSubsection
-            key={applicantSection.identifier}
-            formName={formName}
-            path={['form', ApplicationSectionKeys.Subsections]}
-            section={applicantSection}
-            headerTag="h2"
-            flavor={ApplicationFormTopLevelSectionFlavor.APPLICANT}
-            isSaveClicked={isSaveClicked}
-          />
-        </div>
+        <>
+          <p>Hello there!</p>
+          <div className="AreaSearchApplicationForm__section">
+            <ApplicationFormSubsection
+              key={applicantSection.identifier}
+              formName={formName}
+              path={['form', ApplicationSectionKeys.Subsections]}
+              section={applicantSection}
+              headerTag="h2"
+              flavor={ApplicationFormTopLevelSectionFlavor.APPLICANT}
+              isSaveClicked={isSaveClicked}
+            />
+          </div>
+        </>
       )}
       {extraSections.length > 0 && (
         <div className="AreaSearchApplicationForm__section">

--- a/src/areaSearch/components/applicationForm.tsx
+++ b/src/areaSearch/components/applicationForm.tsx
@@ -39,7 +39,6 @@ const ApplicationForm = ({
     <form className="AreaSearchApplicationForm">
       {applicantSection && (
         <>
-          <p>Hello there!</p>
           <div className="AreaSearchApplicationForm__section">
             <ApplicationFormSubsection
               key={applicantSection.identifier}

--- a/src/areaSearch/reducer.ts
+++ b/src/areaSearch/reducer.ts
@@ -21,7 +21,6 @@ import {
   RECEIVE_AREA_SEARCH_ATTACHMENT_SAVED,
   INITIALIZE_AREA_SEARCH_ATTACHMENTS,
   AreaSearchAttachmentSubmissionFailed,
-  SET_NEXT_AREA_SEARCH_APPLICATION_STEP,
 } from './types';
 
 type CurrentDisplayState = {
@@ -65,9 +64,6 @@ const areaSearchSlice = createSlice({
         state.isSubmittingAreaSearchAttachments = false;
         state.areaSearchAttachments = [];
       })
-      .addCase(SET_NEXT_AREA_SEARCH_APPLICATION_STEP, (state) => {
-        state.currentStep += 1;
-      })
       .addCase(SUBMIT_AREA_SEARCH_ATTACHMENT, (state) => {
         state.isSubmittingAreaSearchAttachments = true;
         state.areaSearchAttachmentError = null;
@@ -97,6 +93,7 @@ const areaSearchSlice = createSlice({
         RECEIVE_AREA_SEARCH_SAVED,
         (state, { payload }: ReceiveAreaSearchSavedAction) => {
           state.isSubmittingAreaSearch = false;
+          state.currentStep = 1;
           state.lastSubmissionId = payload.id;
           state.lastSubmission = payload;
         },

--- a/src/areaSearch/reducer.ts
+++ b/src/areaSearch/reducer.ts
@@ -21,9 +21,11 @@ import {
   RECEIVE_AREA_SEARCH_ATTACHMENT_SAVED,
   INITIALIZE_AREA_SEARCH_ATTACHMENTS,
   AreaSearchAttachmentSubmissionFailed,
+  SET_NEXT_AREA_SEARCH_APPLICATION_STEP,
 } from './types';
 
 type CurrentDisplayState = {
+  currentStep: number;
   isSubmittingAreaSearch: boolean;
   lastError: unknown | null;
   lastSubmissionId: number;
@@ -38,6 +40,7 @@ type CurrentDisplayState = {
 };
 
 const initialState: CurrentDisplayState = {
+  currentStep: 0,
   isSubmittingAreaSearch: false,
   lastError: null,
   lastSubmissionId: 0,
@@ -61,6 +64,9 @@ const areaSearchSlice = createSlice({
         state.areaSearchAttachmentError = null;
         state.isSubmittingAreaSearchAttachments = false;
         state.areaSearchAttachments = [];
+      })
+      .addCase(SET_NEXT_AREA_SEARCH_APPLICATION_STEP, (state) => {
+        state.currentStep += 1;
       })
       .addCase(SUBMIT_AREA_SEARCH_ATTACHMENT, (state) => {
         state.isSubmittingAreaSearchAttachments = true;

--- a/src/areaSearch/requests.ts
+++ b/src/areaSearch/requests.ts
@@ -21,13 +21,14 @@ export const submitAreaSearchAttachmentRequest = ({
       method: 'POST',
       body: formData,
     }),
-    { autoContentType: false }
+    { autoContentType: false },
   );
 };
 
 export const submitAreaSearchRequest = ({
   area_search_attachments,
   geometry,
+  id,
   ...rest
 }: AreaSearchSubmission): Generator<Effect, ApiCallResult, Response> => {
   const payload = {
@@ -36,22 +37,31 @@ export const submitAreaSearchRequest = ({
     ...rest,
   };
 
-  return callApi(
-    new Request(createUrl('area_search/'), {
-      method: 'POST',
-      body: JSON.stringify(payload),
-    })
-  );
+  if (id) {
+    return callApi(
+      new Request(createUrl(`area_search/${id}/`), {
+        method: 'PUT',
+        body: JSON.stringify(payload),
+      }),
+    );
+  } else {
+    return callApi(
+      new Request(createUrl('area_search/'), {
+        method: 'POST',
+        body: JSON.stringify(payload),
+      }),
+    );
+  }
 };
 
 export const submitAreaSearchApplicationRequest = (
-  formData: AreaSearchApplicationSubmission
+  formData: AreaSearchApplicationSubmission,
 ): Generator<Effect, ApiCallResult, Response> => {
   return callApi(
     new Request(createUrl('answer/'), {
       method: 'POST',
       body: JSON.stringify(formData),
-    })
+    }),
   );
 };
 
@@ -64,7 +74,7 @@ export const fetchIntendedUsesRequest = (): Generator<
     new Request(
       createUrl('intended_use/', {
         limit: '9999',
-      })
-    )
+      }),
+    ),
   );
 };

--- a/src/areaSearch/saga.ts
+++ b/src/areaSearch/saga.ts
@@ -26,6 +26,7 @@ import {
   receiveAreaSearchAttachmentSaved,
   receiveAreaSearchSaved,
   receiveIntendedUses,
+  setNextStep,
 } from './actions';
 import { UploadedFileMeta } from '../application/types';
 
@@ -47,7 +48,7 @@ function* submitAreaSearchSaga({
               try {
                 const { response, bodyAsJson } = yield call(
                   submitAreaSearchAttachmentRequest,
-                  fileData
+                  fileData,
                 );
                 switch (response.status) {
                   case 200:
@@ -62,7 +63,7 @@ function* submitAreaSearchSaga({
                     failedAttachmentUploads.push(
                       typeof attachment === 'number'
                         ? String(attachment)
-                        : attachment.name
+                        : attachment.name,
                     );
                     break;
                 }
@@ -72,7 +73,7 @@ function* submitAreaSearchSaga({
                 failedAttachmentUploads.push(
                   typeof attachment === 'number'
                     ? String(attachment)
-                    : attachment.name
+                    : attachment.name,
                 );
                 throw e;
               }
@@ -83,9 +84,9 @@ function* submitAreaSearchSaga({
                 file: attachment,
               },
               callback: (file: UploadedFileMeta) => pushAttachmentIds(file.id),
-            }
-          )
-        )
+            },
+          ),
+        ),
       );
     }
 
@@ -93,7 +94,7 @@ function* submitAreaSearchSaga({
       yield put(
         areaSearchSubmissionFailed({
           failedAttachments: failedAttachmentUploads,
-        })
+        }),
       );
       return;
     }
@@ -102,12 +103,13 @@ function* submitAreaSearchSaga({
 
     const { response, bodyAsJson } = yield call(
       submitAreaSearchRequest,
-      newPayload
+      newPayload,
     );
 
     switch (response.status) {
       case 200:
       case 201:
+        yield put(setNextStep());
         yield put(receiveAreaSearchSaved(bodyAsJson as AreaSearch));
         break;
       default:
@@ -126,7 +128,7 @@ function* submitAreaSearchApplicationSaga({
   try {
     const { response, bodyAsJson } = yield call(
       submitAreaSearchApplicationRequest,
-      payload
+      payload,
     );
 
     switch (response.status) {
@@ -155,7 +157,7 @@ export function* fetchIntendedUsesSaga(): Generator<
     switch (response.status) {
       case 200:
         yield put(
-          receiveIntendedUses(bodyAsJson.results as Array<IntendedUse>)
+          receiveIntendedUses(bodyAsJson.results as Array<IntendedUse>),
         );
         break;
       default:
@@ -173,7 +175,7 @@ export default function* areaSearchSaga(): Generator {
       yield takeLatest(SUBMIT_AREA_SEARCH, submitAreaSearchSaga);
       yield takeLatest(
         SUBMIT_AREA_SEARCH_APPLICATION,
-        submitAreaSearchApplicationSaga
+        submitAreaSearchApplicationSaga,
       );
       yield takeLatest(FETCH_INTENDED_USES, fetchIntendedUsesSaga);
     }),

--- a/src/areaSearch/saga.ts
+++ b/src/areaSearch/saga.ts
@@ -10,6 +10,8 @@ import {
   AreaSearch,
   SUBMIT_AREA_SEARCH_APPLICATION,
   SubmitAreaSearchApplicationAction,
+  SET_NEXT_AREA_SEARCH_APPLICATION_STEP,
+  RECEIVE_AREA_SEARCH_SAVED,
 } from './types';
 import {
   fetchIntendedUsesRequest,
@@ -109,8 +111,8 @@ function* submitAreaSearchSaga({
     switch (response.status) {
       case 200:
       case 201:
-        yield put(setNextStep());
         yield put(receiveAreaSearchSaved(bodyAsJson as AreaSearch));
+        yield put(setNextStep());
         break;
       default:
         yield put(areaSearchSubmissionFailed(bodyAsJson));
@@ -121,6 +123,10 @@ function* submitAreaSearchSaga({
     yield put(areaSearchSubmissionFailed(e));
   }
 }
+
+// function* setNextStepSaga() {
+//   yield call(setNextStep)
+// }
 
 function* submitAreaSearchApplicationSaga({
   payload,

--- a/src/areaSearch/saga.ts
+++ b/src/areaSearch/saga.ts
@@ -1,4 +1,12 @@
-import { all, call, Effect, fork, put, takeLatest } from 'redux-saga/effects';
+import {
+  all,
+  call,
+  Effect,
+  fork,
+  put,
+  take,
+  takeLatest,
+} from 'redux-saga/effects';
 
 import { ApiCallResult } from '../api/callApi';
 import { logError } from '../root/helpers';
@@ -10,6 +18,8 @@ import {
   AreaSearch,
   SUBMIT_AREA_SEARCH_APPLICATION,
   SubmitAreaSearchApplicationAction,
+  RECEIVE_AREA_SEARCH_SAVED,
+  AREA_SEARCH_FORM_NAME,
 } from './types';
 import {
   fetchIntendedUsesRequest,
@@ -28,6 +38,7 @@ import {
   receiveIntendedUses,
 } from './actions';
 import { UploadedFileMeta } from '../application/types';
+import { setSubmitSucceeded } from 'redux-form';
 
 function* submitAreaSearchSaga({
   payload,
@@ -167,10 +178,15 @@ export function* fetchIntendedUsesSaga(): Generator<
   }
 }
 
+function* jee(): Generator {
+  yield put(setSubmitSucceeded(AREA_SEARCH_FORM_NAME));
+}
+
 export default function* areaSearchSaga(): Generator {
   yield all([
     fork(function* (): Generator {
       yield takeLatest(SUBMIT_AREA_SEARCH, submitAreaSearchSaga);
+      yield takeLatest(RECEIVE_AREA_SEARCH_SAVED, jee);
       yield takeLatest(
         SUBMIT_AREA_SEARCH_APPLICATION,
         submitAreaSearchApplicationSaga,

--- a/src/areaSearch/saga.ts
+++ b/src/areaSearch/saga.ts
@@ -10,8 +10,6 @@ import {
   AreaSearch,
   SUBMIT_AREA_SEARCH_APPLICATION,
   SubmitAreaSearchApplicationAction,
-  SET_NEXT_AREA_SEARCH_APPLICATION_STEP,
-  RECEIVE_AREA_SEARCH_SAVED,
 } from './types';
 import {
   fetchIntendedUsesRequest,
@@ -28,7 +26,6 @@ import {
   receiveAreaSearchAttachmentSaved,
   receiveAreaSearchSaved,
   receiveIntendedUses,
-  setNextStep,
 } from './actions';
 import { UploadedFileMeta } from '../application/types';
 
@@ -112,7 +109,6 @@ function* submitAreaSearchSaga({
       case 200:
       case 201:
         yield put(receiveAreaSearchSaved(bodyAsJson as AreaSearch));
-        yield put(setNextStep());
         break;
       default:
         yield put(areaSearchSubmissionFailed(bodyAsJson));
@@ -123,10 +119,6 @@ function* submitAreaSearchSaga({
     yield put(areaSearchSubmissionFailed(e));
   }
 }
-
-// function* setNextStepSaga() {
-//   yield call(setNextStep)
-// }
 
 function* submitAreaSearchApplicationSaga({
   payload,

--- a/src/areaSearch/types.ts
+++ b/src/areaSearch/types.ts
@@ -62,7 +62,6 @@ export type AreaSearchSubmission = {
   geometry: Geometry | null;
   area_search_attachments: Array<number> | Array<File>;
   id?: number; // For PUT operations
-  setNextStep: Function;
 };
 
 export type AreaSearchApplicationSubmission = {
@@ -75,12 +74,6 @@ export type IntendedUse = {
   id: number;
   name: string;
 };
-
-export const SET_NEXT_AREA_SEARCH_APPLICATION_STEP =
-  'areaSearch/SET_NEXT_AREA_SEARCH_APPLICATION_STEP';
-export interface SetNextAreaSearchStepAction {
-  type: typeof SET_NEXT_AREA_SEARCH_APPLICATION_STEP;
-}
 
 export const SUBMIT_AREA_SEARCH = 'areaSearch/SUBMIT_AREA_SEARCH';
 export interface SubmitAreaSearchAction {

--- a/src/areaSearch/types.ts
+++ b/src/areaSearch/types.ts
@@ -61,6 +61,8 @@ export type AreaSearchSubmission = {
   intended_use: number;
   geometry: Geometry | null;
   area_search_attachments: Array<number> | Array<File>;
+  id?: number; // For PUT operations
+  setNextStep: Function;
 };
 
 export type AreaSearchApplicationSubmission = {
@@ -73,6 +75,12 @@ export type IntendedUse = {
   id: number;
   name: string;
 };
+
+export const SET_NEXT_AREA_SEARCH_APPLICATION_STEP =
+  'areaSearch/SET_NEXT_AREA_SEARCH_APPLICATION_STEP';
+export interface SetNextAreaSearchStepAction {
+  type: typeof SET_NEXT_AREA_SEARCH_APPLICATION_STEP;
+}
 
 export const SUBMIT_AREA_SEARCH = 'areaSearch/SUBMIT_AREA_SEARCH';
 export interface SubmitAreaSearchAction {


### PR DESCRIPTION
Currently, the area search specs creates a new area search each time the specs form is submitted. This will change the functionality so that if the user has already submitted the area search specs, and then returns to edit and re-submit it, the existing area search is updated instead of creating a new one.