### PR TITLE
Update Area Search Specs with PUT

### DIFF
--- a/src/areaSearch/actions.ts
+++ b/src/areaSearch/actions.ts
@@ -20,10 +20,13 @@ import {
   AREA_SEARCH_ATTACHMENT_SUBMISSION_FAILED,
   RECEIVE_AREA_SEARCH_ATTACHMENT_SAVED,
   INITIALIZE_AREA_SEARCH_ATTACHMENTS,
+  SET_AREA_SEARCH_STEP,
+  RESET_AREA_SEARCH_STATE,
+  SET_UP_AREA_SEARCH_APPLICATION_FORM,
 } from './types';
 
 export const submitAreaSearch = (
-  payload: AreaSearchSubmission
+  payload: AreaSearchSubmission,
 ): Action<string> => createAction(SUBMIT_AREA_SEARCH)(payload);
 
 export const submitAreaSearchAttachment = (payload: {
@@ -34,16 +37,25 @@ export const submitAreaSearchAttachment = (payload: {
   callback?: (file: UploadedFileMeta) => void;
 }): Action<string> => createAction(SUBMIT_AREA_SEARCH_ATTACHMENT)(payload);
 
+export const resetAreaSearchState = (): Action<string> =>
+  createAction(RESET_AREA_SEARCH_STATE)();
+
 export const initializeAreaSearchAttachments = (): Action<string> =>
   createAction(INITIALIZE_AREA_SEARCH_ATTACHMENTS)();
 
+export const setAreaSearchStep = (payload: number): Action<string> =>
+  createAction(SET_AREA_SEARCH_STEP)(payload);
+
+export const setUpAreaSearchApplicationForm = (): Action<string> =>
+  createAction(SET_UP_AREA_SEARCH_APPLICATION_FORM)();
+
 export const areaSearchAttachmentSubmissionFailed = (
-  payload: unknown
+  payload: unknown,
 ): Action<string> =>
   createAction(AREA_SEARCH_ATTACHMENT_SUBMISSION_FAILED)(payload);
 
 export const receiveAreaSearchAttachmentSaved = (
-  payload: File
+  payload: File,
 ): Action<string> =>
   createAction(RECEIVE_AREA_SEARCH_ATTACHMENT_SAVED)(payload);
 
@@ -54,16 +66,16 @@ export const areaSearchSubmissionFailed = (payload: unknown): Action<string> =>
   createAction(AREA_SEARCH_SUBMISSION_FAILED)(payload);
 
 export const submitAreaSearchApplication = (
-  payload: AreaSearchApplicationSubmission
+  payload: AreaSearchApplicationSubmission,
 ): Action<string> => createAction(SUBMIT_AREA_SEARCH_APPLICATION)(payload);
 
 export const receiveAreaSearchApplicationSaved = (
-  payload: AreaSearch
+  payload: AreaSearch,
 ): Action<string> =>
   createAction(RECEIVE_AREA_SEARCH_APPLICATION_SAVED)(payload);
 
 export const areaSearchApplicationSubmissionFailed = (
-  payload: unknown
+  payload: unknown,
 ): Action<string> =>
   createAction(AREA_SEARCH_APPLICATION_SUBMISSION_FAILED)(payload);
 
@@ -71,7 +83,7 @@ export const fetchIntendedUses = (): Action<string> =>
   createAction(FETCH_INTENDED_USES)();
 
 export const receiveIntendedUses = (
-  payload: Array<IntendedUse>
+  payload: Array<IntendedUse>,
 ): Action<string> => createAction(RECEIVE_INTENDED_USES)(payload);
 
 export const intendedUsesNotFound = (): Action<string> =>

--- a/src/areaSearch/areaSearchApplicationPreview.tsx
+++ b/src/areaSearch/areaSearchApplicationPreview.tsx
@@ -23,12 +23,13 @@ import {
   AreaSearchFormRoot,
   AREA_SEARCH_FORM_NAME,
 } from './types';
-import { submitAreaSearchApplication } from './actions';
+import { setAreaSearchStep, submitAreaSearchApplication } from './actions';
 import ApplicationPreviewSubsection from '../application/components/applicationPreviewSubsection';
 import { getClientErrorMessage } from '../application/helpers';
 import { prepareAreaSearchApplicationForSubmission } from './helpers';
 import ApplicationProcedureInfo from '../application/components/ApplicationProcedureInfo';
 import ScrollToTop from '../common/ScrollToTop';
+import { AreaSearchStepperPageIndex } from './helpers';
 
 interface State {
   lastSubmission: AreaSearch | null;
@@ -38,12 +39,10 @@ interface State {
   lastError: unknown;
   isSubmitting?: boolean;
 }
-
 interface Props extends State {
   submitApplication: (data: AreaSearchApplicationSubmission) => void;
   isSubmitting?: boolean;
-  setNextStep: Function;
-  setPreviousStep: Function;
+  setAreaSearchStep: typeof setAreaSearchStep;
 }
 
 const AreaSearchApplicationPreview = ({
@@ -53,8 +52,7 @@ const AreaSearchApplicationPreview = ({
   lastError,
   isSubmitting,
   submittedAnswerId,
-  setNextStep,
-  setPreviousStep,
+  setAreaSearchStep,
 }: Props): JSX.Element => {
   const { t } = useTranslation();
 
@@ -65,7 +63,7 @@ const AreaSearchApplicationPreview = ({
 
   useEffect(() => {
     if (submittedAnswerId !== previousAnswerId) {
-      setNextStep();
+      setAreaSearchStep(AreaSearchStepperPageIndex.SUCCESS);
     }
   }, [submittedAnswerId]);
 
@@ -100,7 +98,7 @@ const AreaSearchApplicationPreview = ({
         />
       ));
     } else {
-      setPreviousStep();
+      setAreaSearchStep(AreaSearchStepperPageIndex.APPLICATION);
     }
   };
 
@@ -142,7 +140,9 @@ const AreaSearchApplicationPreview = ({
                   {renderSectionPreviewsOrGoBack(loggedIn)}
                   <Button
                     variant="secondary"
-                    onClick={() => setPreviousStep()}
+                    onClick={() =>
+                      setAreaSearchStep(AreaSearchStepperPageIndex.APPLICATION)
+                    }
                     disabled={isSubmitting}
                     className="ApplicationPreviewPage__submission-button"
                   >
@@ -206,6 +206,7 @@ export default connect(
     isSubmitting: state.areaSearch.isSubmittingAreaSearchApplication,
   }),
   {
+    setAreaSearchStep,
     submitApplication: submitAreaSearchApplication,
   },
 )(AreaSearchApplicationPreview);

--- a/src/areaSearch/areaSearchApplicationRootPage.tsx
+++ b/src/areaSearch/areaSearchApplicationRootPage.tsx
@@ -23,10 +23,14 @@ import { Container } from 'react-grid-system';
 import AuthDependentContent from '../auth/components/authDependentContent';
 import { openLoginModal } from '../login/actions';
 import ScrollToTop from '../common/ScrollToTop';
+import { resetAreaSearchState, setAreaSearchStep } from './actions';
+import { AreaSearchStepperPageIndex } from './helpers';
+import { FileUploadsProvider } from '../form/FileUploadsContext';
 
 interface State {
   areaSearchForm: null;
   lastSubmission: AreaSearch | null;
+  currentStep: number;
 }
 
 interface Step {
@@ -38,6 +42,8 @@ export interface Props extends State {
   openLoginModal: () => void;
   initializeForm: typeof initialize;
   fetchFormAttributes: () => void;
+  setAreaSearchStep: typeof setAreaSearchStep;
+  resetAreaSearchState: typeof resetAreaSearchState;
 }
 
 const AreaSearchApplicationRootPage = ({
@@ -45,17 +51,10 @@ const AreaSearchApplicationRootPage = ({
   initializeForm,
   fetchFormAttributes,
   valid,
+  currentStep,
+  setAreaSearchStep,
+  resetAreaSearchState,
 }: Props & InjectedFormProps<unknown, Props>): JSX.Element => {
-  const [currentStep, setCurrentStep] = useState<number>(0);
-
-  const setNextStep = () => {
-    setCurrentStep(currentStep + 1);
-  };
-
-  const setPreviousStep = () => {
-    setCurrentStep(currentStep - 1);
-  };
-
   const [steps, setSteps] = useState<Step[]>([
     {
       label: 'Alueen valinta',
@@ -78,16 +77,11 @@ const AreaSearchApplicationRootPage = ({
   const renderCurrentStep = () => {
     switch (steps[currentStep].label) {
       case 'Alueen valinta':
-        return <AreaSearchSpecsPage valid={valid} setNextStep={setNextStep} />;
+        return <AreaSearchSpecsPage valid={valid} />;
       case 'Hakemuksen täyttö':
-        return <AreaSearchApplicationPage setNextStep={setNextStep} />;
+        return <AreaSearchApplicationPage />;
       case 'Esikatselu':
-        return (
-          <AreaSearchApplicationPreview
-            setPreviousStep={setPreviousStep}
-            setNextStep={setNextStep}
-          />
-        );
+        return <AreaSearchApplicationPreview />;
       case 'Lähetys':
         return <AreaSearchApplicationSuccessPage />;
       default:
@@ -97,23 +91,24 @@ const AreaSearchApplicationRootPage = ({
 
   const updateStepAvailability = () => {
     const newSteps = [...steps];
+    const { SPECS, APPLICATION, PREVIEW, SUCCESS } = AreaSearchStepperPageIndex;
 
     switch (currentStep) {
-      case 0:
-        newSteps[1].state = StepState.disabled;
-        newSteps[2].state = StepState.disabled;
+      case SPECS:
+        newSteps[APPLICATION].state = StepState.disabled;
+        newSteps[PREVIEW].state = StepState.disabled;
         break;
-      case 1:
-        newSteps[1].state = StepState.available;
+      case APPLICATION:
+        newSteps[APPLICATION].state = StepState.available;
         if (valid) {
-          newSteps[2].state = StepState.available;
+          newSteps[PREVIEW].state = StepState.available;
         } else {
-          newSteps[2].state = StepState.disabled;
+          newSteps[PREVIEW].state = StepState.disabled;
         }
         break;
-      case 2:
+      case PREVIEW:
         break;
-      case 3:
+      case SUCCESS:
         newSteps.forEach((step) => (step.state = StepState.disabled));
         break;
     }
@@ -122,11 +117,12 @@ const AreaSearchApplicationRootPage = ({
   };
 
   useEffect(() => {
+    resetAreaSearchState();
     initializeForm(AREA_SEARCH_FORM_NAME, initializeAreaSearchForm());
-  }, []);
-
-  useEffect(() => {
     fetchFormAttributes();
+    return () => {
+      resetAreaSearchState();
+    };
   }, []);
 
   useEffect(() => {
@@ -141,41 +137,46 @@ const AreaSearchApplicationRootPage = ({
         </title>
       </Helmet>
       <Container>
-        <AuthDependentContent>
-          {(_, loggedIn) =>
-            loggedIn ? (
-              <>
-                <div className="AreaSearchStepperWrapper">
-                  <Stepper
-                    steps={steps}
-                    language="en"
-                    selectedStep={currentStep}
-                    onStepClick={(_, nextPageIndex) =>
-                      setCurrentStep(nextPageIndex)
-                    }
-                  />
-                </div>
-                {renderCurrentStep()}
-              </>
-            ) : (
-              <>
-                <ScrollToTop />
-                <h1>
-                  {t('areaSearch.specs.heading', 'Apply for a land area lease')}
-                </h1>
-                <p>
-                  {t(
-                    'areaSearch.specs.notLoggedIn',
-                    'To apply, please log in first.',
-                  )}
-                </p>
-                <Button variant="primary" onClick={() => openLoginModal()}>
-                  {t('areaSearch.specs.loginButton', 'Log in')}
-                </Button>
-              </>
-            )
-          }
-        </AuthDependentContent>
+        <FileUploadsProvider>
+          <AuthDependentContent>
+            {(_, loggedIn) =>
+              loggedIn ? (
+                <>
+                  <div className="AreaSearchStepperWrapper">
+                    <Stepper
+                      steps={steps}
+                      language="en"
+                      selectedStep={currentStep}
+                      onStepClick={(_, targetStepIndex) =>
+                        setAreaSearchStep(targetStepIndex)
+                      }
+                    />
+                  </div>
+                  {renderCurrentStep()}
+                </>
+              ) : (
+                <>
+                  <ScrollToTop />
+                  <h1>
+                    {t(
+                      'areaSearch.specs.heading',
+                      'Apply for a land area lease',
+                    )}
+                  </h1>
+                  <p>
+                    {t(
+                      'areaSearch.specs.notLoggedIn',
+                      'To apply, please log in first.',
+                    )}
+                  </p>
+                  <Button variant="primary" onClick={() => openLoginModal()}>
+                    {t('areaSearch.specs.loginButton', 'Log in')}
+                  </Button>
+                </>
+              )
+            }
+          </AuthDependentContent>
+        </FileUploadsProvider>
       </Container>
     </MainContentElement>
   );
@@ -185,11 +186,14 @@ export default connect(
   (state: RootState): State => ({
     areaSearchForm: null,
     lastSubmission: state.areaSearch.lastSubmission,
+    currentStep: state.areaSearch.currentStep,
   }),
   {
     openLoginModal,
     initializeForm: initialize,
     fetchFormAttributes,
+    setAreaSearchStep,
+    resetAreaSearchState,
   },
 )(
   reduxForm<unknown, Props>({

--- a/src/areaSearch/areaSearchSpecsPage.tsx
+++ b/src/areaSearch/areaSearchSpecsPage.tsx
@@ -9,6 +9,7 @@ import {
   startSubmit,
   touch,
   change,
+  FormAction,
 } from 'redux-form';
 import { Col, Row } from 'react-grid-system';
 import { Button, Notification } from 'hds-react';
@@ -20,10 +21,7 @@ import { openLoginModal } from '../login/actions';
 import TextAreaFormField from '../form/TextAreaFormField';
 import DateInputFormField from '../form/DateInputFormField';
 import SelectFormField from '../form/SelectFormField';
-import {
-  FileUploadsProvider,
-  useFileUploads,
-} from '../form/FileUploadsContext';
+import { useFileUploads } from '../form/FileUploadsContext';
 import FileInputFormField from '../form/FileInputFormField';
 import {
   dateAfterOrEqualValidatorGenerator,
@@ -33,7 +31,7 @@ import {
   requiredValidatorGenerator,
 } from '../form/validators';
 import { RootState } from '../root/rootReducer';
-import { AREA_SEARCH_FORM_NAME, IntendedUse } from './types';
+import { AREA_SEARCH_FORM_NAME, AreaSearch, IntendedUse } from './types';
 import {
   fetchIntendedUses,
   initializeAreaSearchAttachments,
@@ -54,6 +52,7 @@ interface State {
   geometry?: MultiPolygon | null;
   descriptionArea?: string;
   intendedUses: Array<IntendedUse> | null;
+  lastSubmission: AreaSearch | null;
   lastSubmissionId: number;
   errors: FormErrors;
   applicationFormTemplate: ApplicationFormRoot;
@@ -68,11 +67,16 @@ interface OwnProps {
   startSubmit: typeof startSubmit;
   setSubmitSucceeded: typeof setSubmitSucceeded;
   isSubmittingAreaSearch: boolean;
-  change: typeof change;
+  change: (
+    form: string,
+    field: string,
+    value: any,
+    touch?: boolean,
+    persistentSubmitErrors?: boolean,
+  ) => FormAction;
   valid: boolean;
   touch(...field: string[]): void;
   lastSubmissionError: unknown;
-  setNextStep: any;
 }
 
 type Props = OwnProps & State;
@@ -97,7 +101,6 @@ const AreaSearchSpecsPage = ({
   lastSubmissionError,
   applicationFormTemplate,
   change,
-  setNextStep,
 }: Props): JSX.Element => {
   const { t } = useTranslation();
 
@@ -175,413 +178,412 @@ const AreaSearchSpecsPage = ({
   useEffect(() => {
     if (!prevSubmissionIdRef.current) {
       change(AREA_SEARCH_FORM_NAME, 'form', applicationFormTemplate, true);
+      initializeAreaSearchAttachments();
     }
+  }, []);
+
+  useEffect(() => {
     if (lastSubmissionId > prevSubmissionIdRef.current) {
       prevSubmissionIdRef.current = lastSubmissionId;
       setSubmitSucceeded(AREA_SEARCH_FORM_NAME);
-      setNextStep();
     }
   }, [lastSubmissionId]);
 
   return (
     <>
       <ScrollToTop />
-      <FileUploadsProvider>
-        <AuthDependentContent>
-          {(loading, loggedIn) => {
-            useEffect(() => {
-              fetchIntendedUses();
-              initializeAreaSearchAttachments();
-            }, []);
+      <AuthDependentContent>
+        {(loading, loggedIn) => {
+          useEffect(() => {
+            fetchIntendedUses();
+          }, []);
 
-            const { files } = useFileUploads();
+          const { files } = useFileUploads();
 
-            if (loading || !intendedUses) {
-              return <BlockLoader />;
-            }
+          if (loading || !intendedUses) {
+            return <BlockLoader />;
+          }
 
-            const onSubmit = (e: FormEvent): void => {
-              e.preventDefault();
+          const onSubmit = (e: FormEvent): void => {
+            e.preventDefault();
 
-              if (valid) {
-                startSubmit(AREA_SEARCH_FORM_NAME);
-                setHasSubmitErrors(false);
-                submitAreaSearch(
-                  prepareAreaSearchSubmission(files['search.attachments']),
+            if (valid) {
+              startSubmit(AREA_SEARCH_FORM_NAME);
+              setHasSubmitErrors(false);
+              const submitParams = {
+                ...prepareAreaSearchSubmission(files['search.attachments']),
+                id: lastSubmissionId && lastSubmissionId,
+              };
+              submitAreaSearch(submitParams);
+            } else {
+              if (touch) {
+                touch(
+                  AREA_SEARCH_FORM_NAME,
+                  ...getFieldNamesFromFormErrors(errors as ReduxFormError),
                 );
-              } else {
-                if (touch) {
-                  touch(
-                    AREA_SEARCH_FORM_NAME,
-                    ...getFieldNamesFromFormErrors(errors as ReduxFormError),
-                  );
-                  setHasSubmitErrors(true);
-                }
+                setHasSubmitErrors(true);
               }
-            };
+            }
+          };
 
-            return (
-              <form onSubmit={onSubmit}>
-                <h1>
-                  {t('areaSearch.specs.heading', 'Apply for a land area lease')}
-                </h1>
+          return (
+            <form onSubmit={onSubmit}>
+              <h1>
+                {t('areaSearch.specs.heading', 'Apply for a land area lease')}
+              </h1>
 
-                {loggedIn ? (
-                  <>
+              {loggedIn ? (
+                <>
+                  <p>
+                    {t(
+                      'areaSearch.specs.explanation',
+                      'If you are willing to lease an area, continue by filling up the application. Please tell us your wishes concerning the area, intended use of the lease and lease time. We will contact you as soon as possible. Fields marked with an asterisk are required.',
+                    )}
+                  </p>
+                  <section>
+                    <h2>
+                      {t(
+                        'areaSearch.specs.intendedUse.heading',
+                        'Specify the intended use and desired time period for the lease',
+                      )}
+                    </h2>
+
+                    <Row className="row">
+                      <Col xs={12} lg={6} xl={4}>
+                        <Field
+                          name="search.intended_use"
+                          component={SelectFormField}
+                          required
+                          options={intendedUses.map((intendedUse) => ({
+                            label: intendedUse.name,
+                            value: intendedUse.id,
+                          }))}
+                          label={t(
+                            'areaSearch.specs.intendedUse.mainType',
+                            'Intended use',
+                          )}
+                          validate={[simpleRequiredValidator]}
+                          placeholder={t(
+                            'areaSearch.specs.intendedUse.mainTypePlaceholder',
+                            'Intended use',
+                          )}
+                        />
+                      </Col>
+                    </Row>
+                    <Row className="row">
+                      <Col xs={12} xl={8}>
+                        <Field
+                          id="description_intended_use"
+                          name="search.description_intended_use"
+                          component={TextAreaFormField}
+                          required
+                          label={t(
+                            'areaSearch.specs.intendedUse.projectDescription',
+                            'Detailed description of intended use',
+                          )}
+                          validate={[simpleRequiredValidator]}
+                          helperText={t(
+                            'areaSearch.specs.intendedUse.projectDescriptionHelpText',
+                            'What kind of activity would you like to carry out on the area? Please describe the project in as much detail as possible.',
+                          )}
+                        />
+                      </Col>
+                    </Row>
+                    <Row className="row">
+                      <Col xs={12} lg={6} xl={4}>
+                        <Field
+                          id="start_date"
+                          name="search.start_date"
+                          component={DateInputFormField}
+                          required
+                          label={t(
+                            'areaSearch.specs.intendedUse.startDate',
+                            'Start date for lease',
+                          )}
+                          helperText={t(
+                            'areaSearch.specs.intendedUse.startDateHelpText',
+                            'Please note that applications will be processed in the order they were submitted.',
+                          )}
+                          minDate={dateNow}
+                          maxDate={lastDate}
+                          validate={[
+                            simpleRequiredValidator,
+                            dateAfterPageLoadValidator,
+                            isBeforeEndDateValidator,
+                          ]}
+                          placeholder="1.1.2021"
+                        />
+                      </Col>
+                      <Col xs={12} lg={6} xl={4}>
+                        <Field
+                          id="end_date"
+                          name="search.end_date"
+                          component={DateInputFormField}
+                          label={t(
+                            'areaSearch.specs.intendedUse.endDate',
+                            'End date for lease',
+                          )}
+                          helperText={t(
+                            'areaSearch.specs.intendedUse.endDateHelpText',
+                            "If you don't yet know the date you'd like the lease to end on or if you'd like to apply for a lease for an indefinite time, please expand on this in the detailed description field above.",
+                          )}
+                          minDate={startDateObject || dateNow}
+                          maxDate={lastDate}
+                          validate={[
+                            dateAfterPageLoadValidator,
+                            isAfterStartDateValidator,
+                          ]}
+                          initialMonth={startDateObject || dateNow}
+                          placeholder="1.1.2021"
+                        />
+                      </Col>
+                    </Row>
+                  </section>
+                  <section>
+                    <h2>
+                      {t(
+                        'areaSearch.specs.area.heading',
+                        "Tell us which area you'd like to lease",
+                      )}
+                    </h2>
+                    <h3>
+                      {t(
+                        'areaSearch.specs.area.drawOnMap.heading',
+                        'Draw the desired area on the map',
+                      )}
+                    </h3>
                     <p>
                       {t(
-                        'areaSearch.specs.explanation',
-                        'If you are willing to lease an area, continue by filling up the application. Please tell us your wishes concerning the area, intended use of the lease and lease time. We will contact you as soon as possible. Fields marked with an asterisk are required.',
+                        'areaSearch.specs.area.drawOnMap.explanation',
+                        "Note that the area you specify will be precursory only. We'll contact you to determine the exact area later during the application handling process. Areas colored in dark gray are not owned by the City of Helsinki.",
                       )}
                     </p>
-                    <section>
-                      <h2>
-                        {t(
-                          'areaSearch.specs.intendedUse.heading',
-                          'Specify the intended use and desired time period for the lease',
-                        )}
-                      </h2>
-
-                      <Row className="row">
-                        <Col xs={12} lg={6} xl={4}>
-                          <Field
-                            name="search.intended_use"
-                            component={SelectFormField}
-                            required
-                            options={intendedUses.map((intendedUse) => ({
-                              label: intendedUse.name,
-                              value: intendedUse.id,
-                            }))}
-                            label={t(
-                              'areaSearch.specs.intendedUse.mainType',
-                              'Intended use',
-                            )}
-                            validate={[simpleRequiredValidator]}
-                            placeholder={t(
-                              'areaSearch.specs.intendedUse.mainTypePlaceholder',
-                              'Intended use',
-                            )}
-                          />
-                        </Col>
-                      </Row>
-                      <Row className="row">
-                        <Col xs={12} xl={8}>
-                          <Field
-                            id="description_intended_use"
-                            name="search.description_intended_use"
-                            component={TextAreaFormField}
-                            required
-                            label={t(
-                              'areaSearch.specs.intendedUse.projectDescription',
-                              'Detailed description of intended use',
-                            )}
-                            validate={[simpleRequiredValidator]}
-                            helperText={t(
-                              'areaSearch.specs.intendedUse.projectDescriptionHelpText',
-                              'What kind of activity would you like to carry out on the area? Please describe the project in as much detail as possible.',
-                            )}
-                          />
-                        </Col>
-                      </Row>
-                      <Row className="row">
-                        <Col xs={12} lg={6} xl={4}>
-                          <Field
-                            id="start_date"
-                            name="search.start_date"
-                            component={DateInputFormField}
-                            required
-                            label={t(
-                              'areaSearch.specs.intendedUse.startDate',
-                              'Start date for lease',
-                            )}
-                            helperText={t(
-                              'areaSearch.specs.intendedUse.startDateHelpText',
-                              'Please note that applications will be processed in the order they were submitted.',
-                            )}
-                            minDate={dateNow}
-                            maxDate={lastDate}
-                            validate={[
-                              simpleRequiredValidator,
-                              dateAfterPageLoadValidator,
-                              isBeforeEndDateValidator,
-                            ]}
-                            placeholder="1.1.2021"
-                          />
-                        </Col>
-                        <Col xs={12} lg={6} xl={4}>
-                          <Field
-                            id="end_date"
-                            name="search.end_date"
-                            component={DateInputFormField}
-                            label={t(
-                              'areaSearch.specs.intendedUse.endDate',
-                              'End date for lease',
-                            )}
-                            helperText={t(
-                              'areaSearch.specs.intendedUse.endDateHelpText',
-                              "If you don't yet know the date you'd like the lease to end on or if you'd like to apply for a lease for an indefinite time, please expand on this in the detailed description field above.",
-                            )}
-                            minDate={startDateObject || dateNow}
-                            maxDate={lastDate}
-                            validate={[
-                              dateAfterPageLoadValidator,
-                              isAfterStartDateValidator,
-                            ]}
-                            initialMonth={startDateObject || dateNow}
-                            placeholder="1.1.2021"
-                          />
-                        </Col>
-                      </Row>
-                    </section>
-                    <section>
-                      <h2>
-                        {t(
-                          'areaSearch.specs.area.heading',
-                          "Tell us which area you'd like to lease",
-                        )}
-                      </h2>
-                      <h3>
-                        {t(
-                          'areaSearch.specs.area.drawOnMap.heading',
-                          'Draw the desired area on the map',
-                        )}
-                      </h3>
-                      <p>
-                        {t(
-                          'areaSearch.specs.area.drawOnMap.explanation',
-                          "Note that the area you specify will be precursory only. We'll contact you to determine the exact area later during the application handling process. Areas colored in dark gray are not owned by the City of Helsinki.",
-                        )}
-                      </p>
-                      <Row className="row">
-                        <Col xs={12}>
-                          <Notification
-                            label={t(
-                              'areaSearch.specs.area.drawOnMap.helpTexts.label',
-                              'Map',
-                            )}
-                          >
-                            <ol>
-                              <li>
-                                {t(
-                                  'areaSearch.specs.area.drawOnMap.helpTexts.phase1',
-                                  'Start by searching',
-                                )}
-                              </li>
-                              <li>
-                                {t(
-                                  'areaSearch.specs.area.drawOnMap.helpTexts.phase2',
-                                  'Draw area',
-                                )}
-                              </li>
-                              <li>
-                                {t(
-                                  'areaSearch.specs.area.drawOnMap.helpTexts.phase3',
-                                  'Drawing is saved automatically',
-                                )}
-                              </li>
-                              <li>
-                                {t(
-                                  'areaSearch.specs.area.drawOnMap.helpTexts.phase4',
-                                  'You can edit your drawing',
-                                )}
-                              </li>
-                            </ol>
-                            <div className="map-icon-container">
-                              <div className="map-icon-container_column">
-                                <div className="map-icon-container_row">
-                                  <img
-                                    src="/zoom-in-out.png"
-                                    alt={t(
-                                      'areaSearch.specs.area.drawOnMap.helpTexts.zoomToolsAlt',
-                                      'Zoom in and out',
-                                    )}
-                                    className="map-icon"
-                                  />
-                                  <span>
-                                    {t(
-                                      'areaSearch.specs.area.drawOnMap.helpTexts.zoomTools',
-                                      'Zoom in and out',
-                                    )}
-                                  </span>
-                                </div>
-                                <div className="map-icon-container_row">
-                                  <img
-                                    src="/draw-tools.png"
-                                    alt={t(
-                                      'areaSearch.specs.area.drawOnMap.helpTexts.drawToolsAlt',
-                                      'Drawing tools',
-                                    )}
-                                    className="map-icon"
-                                  />
-                                  <span>
-                                    {t(
-                                      'areaSearch.specs.area.drawOnMap.helpTexts.drawTools',
-                                      'Drawing tools',
-                                    )}
-                                  </span>
-                                </div>
+                    <Row className="row">
+                      <Col xs={12}>
+                        <Notification
+                          label={t(
+                            'areaSearch.specs.area.drawOnMap.helpTexts.label',
+                            'Map',
+                          )}
+                        >
+                          <ol>
+                            <li>
+                              {t(
+                                'areaSearch.specs.area.drawOnMap.helpTexts.phase1',
+                                'Start by searching',
+                              )}
+                            </li>
+                            <li>
+                              {t(
+                                'areaSearch.specs.area.drawOnMap.helpTexts.phase2',
+                                'Draw area',
+                              )}
+                            </li>
+                            <li>
+                              {t(
+                                'areaSearch.specs.area.drawOnMap.helpTexts.phase3',
+                                'Drawing is saved automatically',
+                              )}
+                            </li>
+                            <li>
+                              {t(
+                                'areaSearch.specs.area.drawOnMap.helpTexts.phase4',
+                                'You can edit your drawing',
+                              )}
+                            </li>
+                          </ol>
+                          <div className="map-icon-container">
+                            <div className="map-icon-container_column">
+                              <div className="map-icon-container_row">
+                                <img
+                                  src="/zoom-in-out.png"
+                                  alt={t(
+                                    'areaSearch.specs.area.drawOnMap.helpTexts.zoomToolsAlt',
+                                    'Zoom in and out',
+                                  )}
+                                  className="map-icon"
+                                />
+                                <span>
+                                  {t(
+                                    'areaSearch.specs.area.drawOnMap.helpTexts.zoomTools',
+                                    'Zoom in and out',
+                                  )}
+                                </span>
                               </div>
-                              <div className="map-icon-container_column">
-                                <div className="map-icon-container_row">
-                                  <img
-                                    src="/edit-tools.png"
-                                    alt={t(
-                                      'areaSearch.specs.area.drawOnMap.helpTexts.editTools',
-                                      'Edit and delete',
-                                    )}
-                                    className="map-icon"
-                                  />
-                                  <span>
-                                    {t(
-                                      'areaSearch.specs.area.drawOnMap.helpTexts.editTools',
-                                      'Edit and delete',
-                                    )}
-                                  </span>
-                                </div>
-                                <div className="map-icon-container_row">
-                                  <img
-                                    src="/map-layers.png"
-                                    alt={t(
-                                      'areaSearch.specs.area.drawOnMap.helpTexts.mapLayers',
-                                      'Map layers',
-                                    )}
-                                    className="map-icon-squared"
-                                  />
-                                  <span>
-                                    {t(
-                                      'areaSearch.specs.area.drawOnMap.helpTexts.mapLayers',
-                                      'Map layers',
-                                    )}
-                                  </span>
-                                </div>
+                              <div className="map-icon-container_row">
+                                <img
+                                  src="/draw-tools.png"
+                                  alt={t(
+                                    'areaSearch.specs.area.drawOnMap.helpTexts.drawToolsAlt',
+                                    'Drawing tools',
+                                  )}
+                                  className="map-icon"
+                                />
+                                <span>
+                                  {t(
+                                    'areaSearch.specs.area.drawOnMap.helpTexts.drawTools',
+                                    'Drawing tools',
+                                  )}
+                                </span>
                               </div>
                             </div>
-                          </Notification>
-                        </Col>
-                      </Row>
-                      <Row className="row">
-                        <Col xs={12}>
-                          <Field
-                            id="geometry"
-                            name="search.geometry"
-                            component={AreaSearchMap}
-                            validate={[
-                              nonEmptyMultiPolygonValidator,
-                              polygonOrDescriptionRequired,
-                            ]}
-                          />
-                        </Col>
-                      </Row>
-                      <Row className="row">
-                        <Col xs={12} xl={8}>
-                          <Field
-                            id="description_area"
-                            name="search.description_area"
-                            component={TextAreaFormField}
-                            label={t(
-                              'areaSearch.specs.area.areaDescription',
-                              'Detailed description of desired area',
-                            )}
-                            helperText={t(
-                              'areaSearch.specs.area.areaDescriptionHelpText',
-                              'Detailed desciption of desired area',
-                            )}
-                            validate={[polygonOrDescriptionRequired]}
-                          />
-                        </Col>
-                      </Row>
-                    </section>
-                    <section>
-                      <h2>
-                        {t(
-                          'areaSearch.specs.attachments.heading',
-                          'Attachments',
-                        )}
-                      </h2>
-                      <Field
-                        id="attachments"
-                        name="search.attachments"
-                        component={FileInputFormField}
-                        label={t(
-                          'areaSearch.specs.attachments.input',
-                          'You may also optionally include any relevant attachments here, such as photos of the area in question.',
-                        )}
-                        dragAndDrop
-                        multiple
-                        maxSize={20 * 1024 * 1024}
-                        helperText={t(
-                          'areaSearch.specs.attachments.inputHelpText',
-                          'Please use PDF files primarily.',
-                        )}
-                      />
-                    </section>
-                    <section className="no-padding">
-                      {hasSubmitErrors && !valid && (
-                        <Notification
-                          className="AreaSearchSpecsPage__submit-error"
-                          type="error"
-                        >
-                          {t(
-                            'areaSearch.specs.errors.validation',
-                            'Please check the marked fields before proceeding.',
-                          )}
+                            <div className="map-icon-container_column">
+                              <div className="map-icon-container_row">
+                                <img
+                                  src="/edit-tools.png"
+                                  alt={t(
+                                    'areaSearch.specs.area.drawOnMap.helpTexts.editTools',
+                                    'Edit and delete',
+                                  )}
+                                  className="map-icon"
+                                />
+                                <span>
+                                  {t(
+                                    'areaSearch.specs.area.drawOnMap.helpTexts.editTools',
+                                    'Edit and delete',
+                                  )}
+                                </span>
+                              </div>
+                              <div className="map-icon-container_row">
+                                <img
+                                  src="/map-layers.png"
+                                  alt={t(
+                                    'areaSearch.specs.area.drawOnMap.helpTexts.mapLayers',
+                                    'Map layers',
+                                  )}
+                                  className="map-icon-squared"
+                                />
+                                <span>
+                                  {t(
+                                    'areaSearch.specs.area.drawOnMap.helpTexts.mapLayers',
+                                    'Map layers',
+                                  )}
+                                </span>
+                              </div>
+                            </div>
+                          </div>
                         </Notification>
+                      </Col>
+                    </Row>
+                    <Row className="row">
+                      <Col xs={12}>
+                        <Field
+                          id="geometry"
+                          name="search.geometry"
+                          component={AreaSearchMap}
+                          validate={[
+                            nonEmptyMultiPolygonValidator,
+                            polygonOrDescriptionRequired,
+                          ]}
+                        />
+                      </Col>
+                    </Row>
+                    <Row className="row">
+                      <Col xs={12} xl={8}>
+                        <Field
+                          id="description_area"
+                          name="search.description_area"
+                          component={TextAreaFormField}
+                          label={t(
+                            'areaSearch.specs.area.areaDescription',
+                            'Detailed description of desired area',
+                          )}
+                          helperText={t(
+                            'areaSearch.specs.area.areaDescriptionHelpText',
+                            'Detailed desciption of desired area',
+                          )}
+                          validate={[polygonOrDescriptionRequired]}
+                        />
+                      </Col>
+                    </Row>
+                  </section>
+                  <section>
+                    <h2>
+                      {t('areaSearch.specs.attachments.heading', 'Attachments')}
+                    </h2>
+                    <Field
+                      id="attachments"
+                      name="search.attachments"
+                      component={FileInputFormField}
+                      label={t(
+                        'areaSearch.specs.attachments.input',
+                        'You may also optionally include any relevant attachments here, such as photos of the area in question.',
                       )}
-                    </section>
-                    <Button
-                      variant="primary"
-                      onClick={(e) => onSubmit(e)}
-                      isLoading={isSubmittingAreaSearch}
-                      loadingText={t(
-                        'areaSearch.specs.submitting',
-                        'Submitting...',
+                      dragAndDrop
+                      multiple
+                      maxSize={20 * 1024 * 1024}
+                      helperText={t(
+                        'areaSearch.specs.attachments.inputHelpText',
+                        'Please use PDF files primarily.',
                       )}
-                      disabled={hasSubmitErrors && !valid}
-                    >
-                      {t(
-                        'areaSearch.specs.continueButton',
-                        'Apply for this area',
-                      )}
-                    </Button>
-                    {lastSubmissionError && (
+                    />
+                  </section>
+                  <section className="no-padding">
+                    {hasSubmitErrors && !valid && (
                       <Notification
                         className="AreaSearchSpecsPage__submit-error"
                         type="error"
                       >
-                        {(
-                          lastSubmissionError as {
-                            failedAttachments: Array<string>;
-                          }
-                        )?.failedAttachments?.length > 0
-                          ? t(
-                              'areaSearch.specs.errors.attachment',
-                              'One or more attachments failed to upload! Please try again.',
-                            )
-                          : t(
-                              'areaSearch.specs.errors.other',
-                              'An unknown error occurred while submitting the area search. Please try again.',
-                            )}
+                        {t(
+                          'areaSearch.specs.errors.validation',
+                          'Please check the marked fields before proceeding.',
+                        )}
                       </Notification>
                     )}
-                  </>
-                ) : (
-                  <>
-                    <p>
-                      {t(
-                        'areaSearch.specs.notLoggedIn',
-                        'To apply, please log in first.',
-                      )}
-                    </p>
-                    <Button variant="primary" onClick={() => openLoginModal()}>
-                      {t('areaSearch.specs.loginButton', 'Log in')}
-                    </Button>
-                  </>
-                )}
-              </form>
-            );
-          }}
-        </AuthDependentContent>
-      </FileUploadsProvider>
+                  </section>
+                  <Button
+                    variant="primary"
+                    onClick={(e) => onSubmit(e)}
+                    isLoading={isSubmittingAreaSearch}
+                    loadingText={t(
+                      'areaSearch.specs.submitting',
+                      'Submitting...',
+                    )}
+                    disabled={hasSubmitErrors && !valid}
+                  >
+                    {t(
+                      'areaSearch.specs.continueButton',
+                      'Apply for this area',
+                    )}
+                  </Button>
+                  {lastSubmissionError && (
+                    <Notification
+                      className="AreaSearchSpecsPage__submit-error"
+                      type="error"
+                    >
+                      {(
+                        lastSubmissionError as {
+                          failedAttachments: Array<string>;
+                        }
+                      )?.failedAttachments?.length > 0
+                        ? t(
+                            'areaSearch.specs.errors.attachment',
+                            'One or more attachments failed to upload! Please try again.',
+                          )
+                        : t(
+                            'areaSearch.specs.errors.other',
+                            'An unknown error occurred while submitting the area search. Please try again.',
+                          )}
+                    </Notification>
+                  )}
+                </>
+              ) : (
+                <>
+                  <p>
+                    {t(
+                      'areaSearch.specs.notLoggedIn',
+                      'To apply, please log in first.',
+                    )}
+                  </p>
+                  <Button variant="primary" onClick={() => openLoginModal()}>
+                    {t('areaSearch.specs.loginButton', 'Log in')}
+                  </Button>
+                </>
+              )}
+            </form>
+          );
+        }}
+      </AuthDependentContent>
     </>
   );
 };
@@ -596,6 +598,7 @@ export default connect(
     descriptionArea: selector(state, 'search.description_area'),
     intendedUses: state.areaSearch.intendedUses,
     isSubmittingAreaSearch: state.areaSearch.isSubmittingAreaSearch,
+    lastSubmission: state.areaSearch.lastSubmission,
     lastSubmissionId: state.areaSearch.lastSubmissionId,
     lastSubmissionError: state.areaSearch.lastError,
     errors: getFormSyncErrors(AREA_SEARCH_FORM_NAME)(state),

--- a/src/areaSearch/helpers.ts
+++ b/src/areaSearch/helpers.ts
@@ -186,7 +186,7 @@ export const prepareAreaSearchApplicationForSubmission = (
               : {
                   ...rest,
                 };
-          }
+          },
         );
       } else {
         const { sections, sectionRestrictions, ...rest } = subsection;
@@ -347,3 +347,10 @@ export const generateAttachmentLink = (
     attachment.id
   }/download`;
 };
+
+export enum AreaSearchStepperPageIndex {
+  SPECS = 0,
+  APPLICATION = 1,
+  PREVIEW = 2,
+  SUCCESS = 3,
+}

--- a/src/areaSearch/reducer.ts
+++ b/src/areaSearch/reducer.ts
@@ -21,9 +21,15 @@ import {
   RECEIVE_AREA_SEARCH_ATTACHMENT_SAVED,
   INITIALIZE_AREA_SEARCH_ATTACHMENTS,
   AreaSearchAttachmentSubmissionFailed,
+  SET_AREA_SEARCH_STEP,
+  SetAreaSearchStepAction,
+  RESET_AREA_SEARCH_STATE,
+  SET_UP_AREA_SEARCH_APPLICATION_FORM,
 } from './types';
+import { AreaSearchStepperPageIndex } from './helpers';
 
 type CurrentDisplayState = {
+  currentStep: number;
   isSubmittingAreaSearch: boolean;
   lastError: unknown | null;
   lastSubmissionId: number;
@@ -35,9 +41,11 @@ type CurrentDisplayState = {
   isSubmittingAreaSearchAttachments: boolean;
   areaSearchAttachments: Array<AreaSearchAttachment>;
   areaSearchAttachmentError: unknown;
+  areaSearchApplicationFormSetUp: boolean;
 };
 
-const initialState: CurrentDisplayState = {
+export const initialState: CurrentDisplayState = {
+  currentStep: 0,
   isSubmittingAreaSearch: false,
   lastError: null,
   lastSubmissionId: 0,
@@ -49,6 +57,7 @@ const initialState: CurrentDisplayState = {
   areaSearchAttachments: [],
   areaSearchAttachmentError: null,
   isSubmittingAreaSearchAttachments: false,
+  areaSearchApplicationFormSetUp: false,
 };
 
 const areaSearchSlice = createSlice({
@@ -62,6 +71,7 @@ const areaSearchSlice = createSlice({
         state.isSubmittingAreaSearchAttachments = false;
         state.areaSearchAttachments = [];
       })
+      .addCase(RESET_AREA_SEARCH_STATE, () => initialState)
       .addCase(SUBMIT_AREA_SEARCH_ATTACHMENT, (state) => {
         state.isSubmittingAreaSearchAttachments = true;
         state.areaSearchAttachmentError = null;
@@ -88,9 +98,19 @@ const areaSearchSlice = createSlice({
         state.lastError = null;
       })
       .addCase(
+        SET_AREA_SEARCH_STEP,
+        (state, { payload }: SetAreaSearchStepAction) => {
+          state.currentStep = payload;
+        },
+      )
+      .addCase(SET_UP_AREA_SEARCH_APPLICATION_FORM, (state) => {
+        state.areaSearchApplicationFormSetUp = true;
+      })
+      .addCase(
         RECEIVE_AREA_SEARCH_SAVED,
         (state, { payload }: ReceiveAreaSearchSavedAction) => {
           state.isSubmittingAreaSearch = false;
+          state.currentStep = AreaSearchStepperPageIndex.APPLICATION;
           state.lastSubmissionId = payload.id;
           state.lastSubmission = payload;
         },

--- a/src/areaSearch/requests.ts
+++ b/src/areaSearch/requests.ts
@@ -21,13 +21,14 @@ export const submitAreaSearchAttachmentRequest = ({
       method: 'POST',
       body: formData,
     }),
-    { autoContentType: false }
+    { autoContentType: false },
   );
 };
 
 export const submitAreaSearchRequest = ({
   area_search_attachments,
   geometry,
+  id,
   ...rest
 }: AreaSearchSubmission): Generator<Effect, ApiCallResult, Response> => {
   const payload = {
@@ -36,22 +37,31 @@ export const submitAreaSearchRequest = ({
     ...rest,
   };
 
-  return callApi(
-    new Request(createUrl('area_search/'), {
-      method: 'POST',
-      body: JSON.stringify(payload),
-    })
-  );
+  if (id) {
+    return callApi(
+      new Request(createUrl(`area_search/${id}/`), {
+        method: 'PUT',
+        body: JSON.stringify(payload),
+      }),
+    );
+  } else {
+    return callApi(
+      new Request(createUrl('area_search/'), {
+        method: 'POST',
+        body: JSON.stringify(payload),
+      }),
+    );
+  }
 };
 
 export const submitAreaSearchApplicationRequest = (
-  formData: AreaSearchApplicationSubmission
+  formData: AreaSearchApplicationSubmission,
 ): Generator<Effect, ApiCallResult, Response> => {
   return callApi(
     new Request(createUrl('answer/'), {
       method: 'POST',
       body: JSON.stringify(formData),
-    })
+    }),
   );
 };
 
@@ -64,7 +74,7 @@ export const fetchIntendedUsesRequest = (): Generator<
     new Request(
       createUrl('intended_use/', {
         limit: '9999',
-      })
-    )
+      }),
+    ),
   );
 };

--- a/src/areaSearch/saga.ts
+++ b/src/areaSearch/saga.ts
@@ -47,7 +47,7 @@ function* submitAreaSearchSaga({
               try {
                 const { response, bodyAsJson } = yield call(
                   submitAreaSearchAttachmentRequest,
-                  fileData
+                  fileData,
                 );
                 switch (response.status) {
                   case 200:
@@ -62,7 +62,7 @@ function* submitAreaSearchSaga({
                     failedAttachmentUploads.push(
                       typeof attachment === 'number'
                         ? String(attachment)
-                        : attachment.name
+                        : attachment.name,
                     );
                     break;
                 }
@@ -72,7 +72,7 @@ function* submitAreaSearchSaga({
                 failedAttachmentUploads.push(
                   typeof attachment === 'number'
                     ? String(attachment)
-                    : attachment.name
+                    : attachment.name,
                 );
                 throw e;
               }
@@ -83,9 +83,9 @@ function* submitAreaSearchSaga({
                 file: attachment,
               },
               callback: (file: UploadedFileMeta) => pushAttachmentIds(file.id),
-            }
-          )
-        )
+            },
+          ),
+        ),
       );
     }
 
@@ -93,7 +93,7 @@ function* submitAreaSearchSaga({
       yield put(
         areaSearchSubmissionFailed({
           failedAttachments: failedAttachmentUploads,
-        })
+        }),
       );
       return;
     }
@@ -102,7 +102,7 @@ function* submitAreaSearchSaga({
 
     const { response, bodyAsJson } = yield call(
       submitAreaSearchRequest,
-      newPayload
+      newPayload,
     );
 
     switch (response.status) {
@@ -126,7 +126,7 @@ function* submitAreaSearchApplicationSaga({
   try {
     const { response, bodyAsJson } = yield call(
       submitAreaSearchApplicationRequest,
-      payload
+      payload,
     );
 
     switch (response.status) {
@@ -155,7 +155,7 @@ export function* fetchIntendedUsesSaga(): Generator<
     switch (response.status) {
       case 200:
         yield put(
-          receiveIntendedUses(bodyAsJson.results as Array<IntendedUse>)
+          receiveIntendedUses(bodyAsJson.results as Array<IntendedUse>),
         );
         break;
       default:
@@ -173,7 +173,7 @@ export default function* areaSearchSaga(): Generator {
       yield takeLatest(SUBMIT_AREA_SEARCH, submitAreaSearchSaga);
       yield takeLatest(
         SUBMIT_AREA_SEARCH_APPLICATION,
-        submitAreaSearchApplicationSaga
+        submitAreaSearchApplicationSaga,
       );
       yield takeLatest(FETCH_INTENDED_USES, fetchIntendedUsesSaga);
     }),

--- a/src/areaSearch/selectors.ts
+++ b/src/areaSearch/selectors.ts
@@ -1,0 +1,7 @@
+import { Selector } from 'react-redux';
+
+import { RootState } from '../root/rootReducer';
+
+export const isAreaSearchApplicationFormSetUp: Selector<RootState, boolean> = (
+  state: RootState,
+): boolean => state.areaSearch.areaSearchApplicationFormSetUp;

--- a/src/areaSearch/types.ts
+++ b/src/areaSearch/types.ts
@@ -61,6 +61,7 @@ export type AreaSearchSubmission = {
   intended_use: number;
   geometry: Geometry | null;
   area_search_attachments: Array<number> | Array<File>;
+  id?: number; // For PUT operations
 };
 
 export type AreaSearchApplicationSubmission = {
@@ -78,6 +79,18 @@ export const SUBMIT_AREA_SEARCH = 'areaSearch/SUBMIT_AREA_SEARCH';
 export interface SubmitAreaSearchAction {
   type: typeof SUBMIT_AREA_SEARCH;
   payload: AreaSearchSubmission;
+}
+
+export const SET_AREA_SEARCH_STEP = 'areaSearch/SET_AREA_SEARCH_STEP';
+export interface SetAreaSearchStepAction {
+  type: typeof SET_AREA_SEARCH_STEP;
+  payload: number;
+}
+
+export const SET_UP_AREA_SEARCH_APPLICATION_FORM =
+  'areaSearch/SET_UP_AREA_SEARCH_APPLICATION_FORM';
+export interface setUpAreaSearchApplicationFormAction {
+  type: typeof SET_UP_AREA_SEARCH_APPLICATION_FORM;
 }
 
 export const RECEIVE_AREA_SEARCH_SAVED = 'areaSearch/RECEIVE_AREA_SEARCH_SAVED';
@@ -109,6 +122,11 @@ export const INITIALIZE_AREA_SEARCH_ATTACHMENTS =
   'areaSearch/INITIALIZE_AREA_SEARCH_ATTACHMENTS';
 export interface InitializeAreaSearchAttachments {
   type: typeof INITIALIZE_AREA_SEARCH_ATTACHMENTS;
+}
+
+export const RESET_AREA_SEARCH_STATE = 'areaSearch/RESET_AREA_SEARCH_STATE';
+export interface ResetAreaSearchState {
+  type: typeof RESET_AREA_SEARCH_STATE;
 }
 
 export const AREA_SEARCH_ATTACHMENT_SUBMISSION_FAILED =

--- a/src/form/FileInputFormField.tsx
+++ b/src/form/FileInputFormField.tsx
@@ -50,10 +50,11 @@ const FileInputFormField = ({
   Props &
   Omit<FileInputProps, 'onChange'>): JSX.Element => {
   const { i18n } = useTranslation();
-  const fileContext = useFileUploads();
+  const { files, setFieldFiles } = useFileUploads();
+  const filesArray = files['search.attachments'];
 
   const onChangeHandler = (files: Array<File>): void => {
-    fileContext.setFieldFiles(input.name, files);
+    setFieldFiles(input.name, files);
     focus(meta.form, input.name);
     touch(meta.form, input.name);
     blur(meta.form, input.name, files.length);
@@ -65,6 +66,7 @@ const FileInputFormField = ({
       onChange={onChangeHandler}
       language={i18n.language as Language}
       errorText={meta.touched && meta.error}
+      defaultValue={filesArray}
       {...rest}
     />
   );

--- a/src/form/SelectFormField.tsx
+++ b/src/form/SelectFormField.tsx
@@ -13,15 +13,9 @@ interface SelectFormFieldOption {
   label: string;
 }
 
-// TODO: Fix dirty hacks that work around the complications stemming from the fact that this component
-//  has to juggle both single and multiple values depending on whether the multiselect prop was passed in.
-//  - Explicit function type recast in onChangeHandler because of the selected value resolving to
-//    OptionType & Array<OptionType> (both a single item and an array simultaneously)
-//  - Internal value passed as an any type, again because something demands that the value has to
-//    exhibit properties of both at the same time
-//  A similar case was discussed in Slack on Feb 11, 2022 (keyword: multiselect)
-//  and no good solution was found at that time. That project elected to create separate
-//  single and multiple select components instead.
+// The HDS Select component type requires the inclusion of both OptionType (single select) and Array<OptionType> (multiselect)
+// But this implementation only supports single selects.
+// TODO: Implement a working multiselect logic when it is needed. Currently (Feb 2024), there is no need for it.
 const SelectFormField = <OptionType extends SelectFormFieldOption>({
   input,
   meta,
@@ -50,33 +44,6 @@ const SelectFormField = <OptionType extends SelectFormFieldOption>({
       return getOptionWithValue(input.value);
     }
   });
-
-  // When the list of available options changes, the current selection should be re-evaluated to make sure
-  // any invalidated options no longer remain in use.
-  useEffect(() => {
-    if (!internalValue) {
-      return;
-    }
-
-    if (Array.isArray(internalValue)) {
-      onChangeHandler(
-        options.filter((option) =>
-          internalValue.some(
-            (singleValue) =>
-              singleValue.value && option.label === singleValue.label,
-          ),
-        ),
-      );
-    } else {
-      onChangeHandler(
-        options.find(
-          (option) =>
-            option.value === internalValue.value &&
-            option.label === internalValue.label,
-        ),
-      );
-    }
-  }, [options]);
 
   const onChangeHandler = (
     selected: Array<OptionType> | OptionType | undefined,


### PR DESCRIPTION
Currently, the area search specs creates a new area search each time the specs form is submitted. This will change the functionality so that if the user has already submitted the area search specs, and then returns to edit and re-submit it, the existing area search is updated instead of creating a new one.