### PR TITLE
Reintroduce hasApiToken to indicate user is logged in

### DIFF
--- a/src/auth/components/authDependentContent.tsx
+++ b/src/auth/components/authDependentContent.tsx
@@ -2,12 +2,18 @@ import { connect } from 'react-redux';
 import type { User } from 'oidc-client-ts';
 
 import { RootState } from '../../root/rootReducer';
-import { getIsFetchingApiToken, getIsLoadingUser, getUser } from '../selectors';
+import {
+  getIsFetchingApiToken,
+  getIsLoadingUser,
+  getUser,
+  hasApiToken,
+} from '../selectors';
 
 interface Props {
   isLoadingUser: boolean;
   isLoadingApiToken: boolean;
   user: User | null;
+  hasApiToken: boolean;
   children: (loading: boolean, loggedIn: boolean) => JSX.Element | null;
 }
 
@@ -15,12 +21,14 @@ const AuthDependentContent = ({
   isLoadingUser,
   isLoadingApiToken,
   user,
+  hasApiToken,
   children,
 }: Props): JSX.Element | null =>
-  children(isLoadingUser || isLoadingApiToken, !!user);
+  children(isLoadingUser || isLoadingApiToken, !!user && hasApiToken);
 
 export default connect((state: RootState) => ({
   user: getUser(state),
   isLoadingUser: getIsLoadingUser(state),
   isLoadingApiToken: getIsFetchingApiToken(state),
+  hasApiToken: hasApiToken(state),
 }))(AuthDependentContent);


### PR DESCRIPTION
This cause an issue in Area Search once we changed intended_uses to require authentication. It was trying to load that before it had apiToken and that failed.

This ensures that `loggedIn` means that user has idToken and apiToken (requested separately from the Oauth flow)