### PR TITLE
Optional field validation: use one identifier, and problem with multiple applicants

### DIFF
--- a/src/application/components/applicationFormSubsection.tsx
+++ b/src/application/components/applicationFormSubsection.tsx
@@ -23,7 +23,7 @@ import {
   ApplicationSectionKeys,
   FieldRendererProps,
   FieldValue,
-  OptionalFieldsCheckboxes,
+  SHOW_IF_FIELD_IDENTIFIER,
   SupportedFieldTypes,
 } from '../types';
 import ApplicationFileUploadField from './applicationFileUploadField';
@@ -270,8 +270,7 @@ const ApplicationFormSubsectionFields = connect(
   };
 
   const optionalFieldsCheckbox: FormField | undefined = section.fields.find(
-    (field) =>
-      Object.values(OptionalFieldsCheckboxes).includes(field.identifier),
+    (field) => field.identifier === SHOW_IF_FIELD_IDENTIFIER,
   );
 
   let optionalFieldsActive: boolean | undefined;
@@ -283,9 +282,8 @@ const ApplicationFormSubsectionFields = connect(
       'fields',
       optionalFieldsCheckbox.identifier,
       'value',
-    ];
-    optionalFieldsActive =
-      getValue(optionalFieldsCheckboxPath.join('.')) === true;
+    ].join('.');
+    optionalFieldsActive = getValue(optionalFieldsCheckboxPath) === true;
   }
 
   useEffect(() => {
@@ -316,7 +314,7 @@ const ApplicationFormSubsectionFields = connect(
     <>
       <Row>
         {optionalFieldsCheckbox && optionalFieldsActive !== true ? (
-          <Fragment key={optionalFieldsCheckbox.identifier}>
+          <Fragment>
             {renderField(identifier, optionalFieldsCheckbox, isSaveClicked)}
           </Fragment>
         ) : (
@@ -332,7 +330,12 @@ const ApplicationFormSubsectionFields = connect(
           formName={formName}
           path={[identifier, ApplicationSectionKeys.Subsections]}
           section={subsection}
-          key={subsection.id}
+          key={[
+            ...path,
+            section.identifier,
+            ApplicationSectionKeys.Subsections,
+            subsection.identifier,
+          ].join('.')}
           parentApplicantType={sectionApplicantType}
           isSaveClicked={isSaveClicked}
         />

--- a/src/application/components/applicationPreviewSubsection.tsx
+++ b/src/application/components/applicationPreviewSubsection.tsx
@@ -1,13 +1,13 @@
 import React from 'react';
 import { FormSection } from '../../plotSearch/types';
 import ApplicationPreviewSubsectionField from './applicationPreviewSubsectionField';
-import { getSectionFavouriteTarget } from '../helpers';
+import { getSectionFavouriteTarget, hideOptionalFields } from '../helpers';
 import {
   ApplicantTypes,
   ApplicationField,
   ApplicationFormNode,
   ApplicationSectionKeys,
-  OptionalFieldsCheckboxes,
+  SHOW_IF_FIELD_IDENTIFIER,
   TARGET_SECTION_IDENTIFIER,
   UploadedFileMeta,
 } from '../types';
@@ -77,14 +77,10 @@ const ApplicationPreviewSubsection = ({
 
   let optionalFieldsCheckbox: ApplicationField | undefined;
   let optionalFieldsActive: boolean | undefined;
-  let answerFields = (answers as ApplicationFormNode).fields;
+  const answerFields = (answers as ApplicationFormNode).fields;
 
   if (answerFields) {
-    const optionalFieldsCheckboxLabel = Object.keys(answerFields).find((key) =>
-      Object.values(OptionalFieldsCheckboxes).includes(key),
-    );
-    optionalFieldsCheckbox =
-      answerFields[optionalFieldsCheckboxLabel as string];
+    optionalFieldsCheckbox = answerFields[SHOW_IF_FIELD_IDENTIFIER];
     optionalFieldsActive = optionalFieldsCheckbox?.value === true;
   }
 

--- a/src/application/helpers.ts
+++ b/src/application/helpers.ts
@@ -15,7 +15,7 @@ import {
   FieldValue,
   NestedField,
   NestedFieldLeaf,
-  OptionalFieldsCheckboxes,
+  SHOW_IF_FIELD_IDENTIFIER,
   SupportedFieldTypes,
   TARGET_SECTION_IDENTIFIER,
 } from './types';
@@ -430,13 +430,10 @@ const getPathParts = (path: string): Array<PathPart> => {
 export const hideOptionalFields = (
   sectionFields: ApplicationFormFields,
 ): boolean => {
-  const optionalFieldsCheckboxLabel: string | undefined = Object.keys(
-    sectionFields,
-  ).find((key) => Object.values(OptionalFieldsCheckboxes).includes(key));
+  const optionalFieldsCheckbox: ApplicationField | undefined =
+    sectionFields[SHOW_IF_FIELD_IDENTIFIER];
 
-  if (optionalFieldsCheckboxLabel) {
-    const optionalFieldsCheckbox: ApplicationField | undefined =
-      sectionFields[optionalFieldsCheckboxLabel];
+  if (optionalFieldsCheckbox) {
     return optionalFieldsCheckbox?.value === false;
   } else {
     return false;

--- a/src/application/types.ts
+++ b/src/application/types.ts
@@ -290,10 +290,6 @@ export enum FieldType {
   DENOMINATOR = 1,
 }
 
-export const OptionalFieldsCheckboxes = {
-  OTHER_THAN_APPLICANT: 'eri-kuin-hakija',
-  APPLICANT_BILLING_ADDRESS: 'laskutusosoite-hakija',
-  OTHER_BILLING_ADDRESS: 'laskutusosoite-muu',
-};
+export const SHOW_IF_FIELD_IDENTIFIER = 'show-if';
 
 export const SPLITTER = ' / ';


### PR DESCRIPTION
1. Use 'show-if' as the only identifier for optional fields checkbox. Related to the backend changes: https://github.com/City-of-Helsinki/mvj/pull/613
2. Fix a React component key issue that caused problems with the optional fields when there were multiple applicants on the form.