### PR TITLE
Mvj 168 areasearch geometry or area description required

### DIFF
--- a/src/areaSearch/areaSearchApplicationRootPage.tsx
+++ b/src/areaSearch/areaSearchApplicationRootPage.tsx
@@ -203,6 +203,7 @@ export default connect(
 )(
   reduxForm<unknown, Props>({
     form: AREA_SEARCH_FORM_NAME,
+    destroyOnUnmount: false,
     shouldError: (...args) =>
       shouldApplicationFormValidate<unknown, Props>(...args),
     validate: (values, props) =>

--- a/src/areaSearch/areaSearchSpecsPage.tsx
+++ b/src/areaSearch/areaSearchSpecsPage.tsx
@@ -29,7 +29,6 @@ import {
   dateAfterOrEqualValidatorGenerator,
   dateBeforeOrEqualValidatorGenerator,
   eitherMultiPolygonOrRequiredValidatorGenerator,
-  nonEmptyMultiPolygonValidatorGenerator,
   requiredValidatorGenerator,
 } from '../form/validators';
 import { RootState } from '../root/rootReducer';
@@ -134,50 +133,42 @@ const AreaSearchSpecsPage = ({
   const simpleRequiredValidator = useMemo<
     ReturnType<typeof requiredValidatorGenerator>
   >(() => requiredValidatorGenerator(), []);
-  const nonEmptyMultiPolygonValidator = useMemo<
-    ReturnType<typeof nonEmptyMultiPolygonValidatorGenerator>
-  >(() => nonEmptyMultiPolygonValidatorGenerator(), []);
-  const dateAfterPageLoadValidator = useMemo<
-    ReturnType<typeof dateAfterOrEqualValidatorGenerator>
-  >(() => dateAfterOrEqualValidatorGenerator(dateNow.toISOString()), []);
   const isBeforeEndDateValidator = useMemo<
     ReturnType<typeof dateBeforeOrEqualValidatorGenerator>
   >(
     () =>
       dateBeforeOrEqualValidatorGenerator(
-        endDate,
         t(
           'areaSearch.specs.errors.startDateBeforeEndDate',
           'Start date cannot be after end date.',
         ),
       ),
-    [startDate, endDate],
+    [],
   );
   const isAfterStartDateValidator = useMemo<
     ReturnType<typeof dateAfterOrEqualValidatorGenerator>
   >(
     () =>
       dateAfterOrEqualValidatorGenerator(
-        startDate,
         t(
           'areaSearch.specs.errors.endDateAfterStartDate',
           'End date cannot be before start date.',
         ),
       ),
-    [startDate, endDate],
+    [],
   );
+
   const polygonOrDescriptionRequired = useMemo<
     ReturnType<typeof eitherMultiPolygonOrRequiredValidatorGenerator>
   >(
     () =>
       eitherMultiPolygonOrRequiredValidatorGenerator(
-        geometry,
         t(
           'areaSearch.specs.errors.eitherPolygonOrDescription',
           'Select either polygon or description.',
         ),
       ),
-    [geometry, descriptionArea],
+    [],
   );
 
   useEffect(() => {
@@ -313,7 +304,6 @@ const AreaSearchSpecsPage = ({
                           maxDate={lastDate}
                           validate={[
                             simpleRequiredValidator,
-                            dateAfterPageLoadValidator,
                             isBeforeEndDateValidator,
                           ]}
                           placeholder={getCurrentDatePlaceholder()}
@@ -334,10 +324,7 @@ const AreaSearchSpecsPage = ({
                           )}
                           minDate={startDateObject || dateNow}
                           maxDate={lastDate}
-                          validate={[
-                            dateAfterPageLoadValidator,
-                            isAfterStartDateValidator,
-                          ]}
+                          validate={[isAfterStartDateValidator]}
                           initialMonth={startDateObject || dateNow}
                           placeholder={getCurrentDatePlaceholder()}
                         />
@@ -476,10 +463,6 @@ const AreaSearchSpecsPage = ({
                           id="geometry"
                           name="search.geometry"
                           component={AreaSearchMap}
-                          validate={[
-                            nonEmptyMultiPolygonValidator,
-                            polygonOrDescriptionRequired,
-                          ]}
                         />
                       </Col>
                     </Row>

--- a/src/areaSearch/requests.ts
+++ b/src/areaSearch/requests.ts
@@ -33,7 +33,7 @@ export const submitAreaSearchRequest = ({
 }: AreaSearchSubmission): Generator<Effect, ApiCallResult, Response> => {
   const payload = {
     area_search_attachments: area_search_attachments,
-    geometry: JSON.stringify(geometry),
+    geometry: geometry ? JSON.stringify(geometry) : null,
     ...rest,
   };
 

--- a/src/form/validators.ts
+++ b/src/form/validators.ts
@@ -124,7 +124,10 @@ export const dateBeforeValidatorGenerator =
  */
 export const dateAfterOrEqualValidatorGenerator =
   (customError?: string) =>
-  (value: string, values: any): string | null => {
+  (
+    value: string,
+    values: { search: { start_date: string } },
+  ): string | null => {
     // values.search contains other fields defined in redux-form form
     if (value && values.search.start_date) {
       const valueDate = new Date(value);
@@ -147,7 +150,7 @@ export const dateAfterOrEqualValidatorGenerator =
  */
 export const dateBeforeOrEqualValidatorGenerator =
   (customError?: string) =>
-  (value: string, values: any): string | null => {
+  (value: string, values: { search: { end_date: string } }): string | null => {
     // values.search contains other fields defined in redux-form form
     if (value && values.search.end_date) {
       const valueDate = new Date(value);
@@ -165,28 +168,15 @@ export const dateBeforeOrEqualValidatorGenerator =
     return null;
   };
 
-export const nonEmptyMultiPolygonValidatorGenerator =
-  (customError?: string) =>
-  (value?: MultiPolygon | null): string | null => {
-    if (value && value.coordinates.length > 0) {
-      return null;
-    }
-
-    return (
-      customError ||
-      i18n.t(
-        'validation.errors.nonEmptyGeometry',
-        'No area has yet been selected.',
-      )
-    );
-  };
-
 /**
  * Generates a validator for redux-form Field component. Expects geometry Field to also exist.
  */
 export const eitherMultiPolygonOrRequiredValidatorGenerator =
   (customError?: string) =>
-  (value: string, values: any): string | null => {
+  (
+    value: string,
+    values: { search: { geometry?: { coordinates: Array<any> } } },
+  ): string | null => {
     // values.search contains other fields defined in redux-form form
     if (values.search.geometry && values.search.geometry.coordinates.length > 0)
       return null;

--- a/src/form/validators.ts
+++ b/src/form/validators.ts
@@ -119,9 +119,13 @@ export const dateBeforeValidatorGenerator =
     return null;
   };
 
+/**
+ * Generates a validator for redux-form Field component. Expects start_date Field to also exist.
+ */
 export const dateAfterOrEqualValidatorGenerator =
   (customError?: string) =>
   (value: string, values: any): string | null => {
+    // values.search contains other fields defined in redux-form form
     if (value && values.search.start_date) {
       const valueDate = new Date(value);
       const comparisonDate = new Date(values.search.start_date);
@@ -138,9 +142,13 @@ export const dateAfterOrEqualValidatorGenerator =
     return null;
   };
 
+/**
+ * Generates a validator for redux-form Field component. Expects end_date Field to also exist.
+ */
 export const dateBeforeOrEqualValidatorGenerator =
   (customError?: string) =>
   (value: string, values: any): string | null => {
+    // values.search contains other fields defined in redux-form form
     if (value && values.search.end_date) {
       const valueDate = new Date(value);
       const comparisonDate = new Date(values.search.end_date);
@@ -173,9 +181,13 @@ export const nonEmptyMultiPolygonValidatorGenerator =
     );
   };
 
+/**
+ * Generates a validator for redux-form Field component. Expects geometry Field to also exist.
+ */
 export const eitherMultiPolygonOrRequiredValidatorGenerator =
   (customError?: string) =>
   (value: string, values: any): string | null => {
+    // values.search contains other fields defined in redux-form form
     if (values.search.geometry && values.search.geometry.coordinates.length > 0)
       return null;
 

--- a/src/form/validators.ts
+++ b/src/form/validators.ts
@@ -120,33 +120,39 @@ export const dateBeforeValidatorGenerator =
   };
 
 export const dateAfterOrEqualValidatorGenerator =
-  (comparisonValue?: string, customError?: string) =>
-  (value?: string): string | null => {
-    if (value && comparisonValue) {
+  (customError?: string) =>
+  (value: string, values: any): string | null => {
+    if (value && values.search.start_date) {
       const valueDate = new Date(value);
-      const comparisonDate = new Date(comparisonValue);
+      const comparisonDate = new Date(values.search.start_date);
 
       if (valueDate.valueOf() === comparisonDate.valueOf()) {
         return null;
       }
 
-      return dateAfterValidatorGenerator(comparisonValue, customError)(value);
+      return dateAfterValidatorGenerator(
+        values.search.start_date,
+        customError,
+      )(value);
     }
     return null;
   };
 
 export const dateBeforeOrEqualValidatorGenerator =
-  (comparisonValue?: string, customError?: string) =>
-  (value?: string): string | null => {
-    if (value && comparisonValue) {
+  (customError?: string) =>
+  (value: string, values: any): string | null => {
+    if (value && values.search.end_date) {
       const valueDate = new Date(value);
-      const comparisonDate = new Date(comparisonValue);
+      const comparisonDate = new Date(values.search.end_date);
 
       if (valueDate.valueOf() === comparisonDate.valueOf()) {
         return null;
       }
 
-      return dateBeforeValidatorGenerator(comparisonValue, customError)(value);
+      return dateBeforeValidatorGenerator(
+        values.search.end_date,
+        customError,
+      )(value);
     }
     return null;
   };
@@ -168,9 +174,10 @@ export const nonEmptyMultiPolygonValidatorGenerator =
   };
 
 export const eitherMultiPolygonOrRequiredValidatorGenerator =
-  (comparisonValue?: MultiPolygon | null, customError?: string) =>
-  (value?: string): string | null => {
-    if (comparisonValue) return null;
+  (customError?: string) =>
+  (value: string, values: any): string | null => {
+    if (values.search.geometry && values.search.geometry.coordinates.length > 0)
+      return null;
 
     if (!value)
       return (


### PR DESCRIPTION
- fixed area search date and geometry/area description validations not being taken into account when redux-form UNREGISTER_FIELD event clears errors after field change (by adding "destroyOnUnmount: false" setting to redux-form)
- fixed area search validations firing before useMemo has time to update validation functions, which caused validations to be run with old data
- Made area search geometry or area description required in validation