### PR TITLE
MVJ-597 use Red Hat UBI images instead of Docker Hub images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,14 +32,14 @@ ENV NPM_CONFIG_LOGLEVEL warn
 # Set node environment, either development or production
 # Use development to install devDependencies
 ARG NODE_ENV=development
-ENV NODE_ENV $NODE_ENV
+ENV NODE_ENV=$NODE_ENV
 
 # Global npm deps in a non-root user directory
 ENV NPM_CONFIG_PREFIX=/app/.npm-global
 ENV PATH=$PATH:/app/.npm-global/bin
 
 # Specify yarn version
-ENV YARN_VERSION 1.22.19
+ENV YARN_VERSION=1.22.19
 RUN yarn policies set-version $YARN_VERSION
 
 # Copy the package and lock files
@@ -47,7 +47,7 @@ USER appuser
 COPY package.json yarn.lock ./
 
 # Install npm dependencies
-ENV PATH /app/node_modules/.bin:$PATH
+ENV PATH=/app/node_modules/.bin:$PATH
 
 USER root
 RUN chown -R appuser:appuser /app /opt/app-root
@@ -63,7 +63,7 @@ FROM appbase as development
 
 # Set NODE_ENV to development in the development container
 ARG NODE_ENV=development
-ENV NODE_ENV $NODE_ENV
+ENV NODE_ENV=$NODE_ENV
 
 # Copy our source code last, as it changes the most
 USER root
@@ -75,7 +75,7 @@ FROM appbase as staticbuilder
 
 # Set NODE_ENV to production in the staticbuilder container
 ARG NODE_ENV=production
-ENV NODE_ENV $NODE_ENV
+ENV NODE_ENV=$NODE_ENV
 
 USER root
 COPY . /app

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
-ARG BUILDER_REGISTRY=registry.access.redhat.com
+ARG CONTAINER_IMAGE_REGISTRY=registry.access.redhat.com
 
 # ===========================================================
-FROM ${BUILDER_REGISTRY}/ubi9/nodejs-18-minimal AS appbase
+FROM ${CONTAINER_IMAGE_REGISTRY}/ubi9/nodejs-18-minimal AS appbase
 # ===========================================================
 
 # Assume the root user for initial installations and setup

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,29 +1,36 @@
-# Should override BUILDER_REGISTRY in the pipeline build-config environment variable section.
-# Red Hat registry is used as a reasonably reliable backup.
 ARG BUILDER_REGISTRY=registry.access.redhat.com
+
+# ===========================================================
 FROM ${BUILDER_REGISTRY}/ubi9/nodejs-18-minimal AS appbase
+# ===========================================================
+
+# Assume the root user for initial installations and setup
+USER root
 
 COPY tools /tools
 COPY scripts /scripts
 ENV PATH="/tools:${PATH}"
 ENV PATH="/scripts:${PATH}"
 
-# Make bash the only shell
-RUN ["chmod", "+x", "/scripts/base_setup.sh"]
-RUN ["chmod", "+x", "/scripts/setup_bash.sh"]
-RUN ["chmod", "+x", "/scripts/setup_dnf_packages.sh"]
-RUN ["chmod", "+x", "/scripts/setup_user.sh"]
-RUN ["chmod", "+x", "/scripts/setup_app_folder.sh"]
-RUN ["chmod", "+x", "/tools/dnf-install.sh"]
-RUN ["chmod", "+x", "/tools/dnf-cleanup.sh"]
-RUN /scripts/base_setup.sh
+# Add the yarn repository to yum/dnf repository list
+RUN curl --silent --location https://dl.yarnpkg.com/rpm/yarn.repo | tee /etc/yum.repos.d/yarn.repo
+
+# Set up the tools and non-root user
+RUN chmod +x /scripts/base_setup.sh && \
+    chmod +x /scripts/setup_bash.sh && \
+    chmod +x /scripts/setup_dnf_packages.sh && \
+    chmod +x /scripts/setup_user.sh && \
+    chmod +x /scripts/setup_app_folder.sh && \
+    chmod +x /tools/dnf-install.sh && \
+    chmod +x /tools/dnf-cleanup.sh && \
+    /scripts/base_setup.sh
 
 WORKDIR /app
 
 ENV NPM_CONFIG_LOGLEVEL warn
 
-# set node environment, either development or production
-# use development to install devDependencies
+# Set node environment, either development or production
+# Use development to install devDependencies
 ARG NODE_ENV=development
 ENV NODE_ENV $NODE_ENV
 
@@ -31,28 +38,24 @@ ENV NODE_ENV $NODE_ENV
 ENV NPM_CONFIG_PREFIX=/app/.npm-global
 ENV PATH=$PATH:/app/.npm-global/bin
 
-# Yarn
+# Specify yarn version
 ENV YARN_VERSION 1.22.19
 RUN yarn policies set-version $YARN_VERSION
 
-# Use non-root user
+# Copy the package and lock files
 USER appuser
-
-# Copy package.json and package-lock.json/yarn.lock files
 COPY package.json yarn.lock ./
 
-# Install npm depepndencies
+# Install npm dependencies
 ENV PATH /app/node_modules/.bin:$PATH
 
 USER root
-RUN bash /tools/dnf-install.sh build-essential
+RUN chown -R appuser:appuser /app /opt/app-root
 
 USER appuser
-RUN yarn config set network-timeout 300000
-RUN yarn && yarn cache clean --force
-
-USER root
-RUN bash /tools/dnf-cleanup.sh build-essential
+RUN yarn config set network-timeout 300000 && \
+    yarn && \
+    yarn cache clean --force
 
 # =============================
 FROM appbase as development
@@ -62,7 +65,8 @@ FROM appbase as development
 ARG NODE_ENV=development
 ENV NODE_ENV $NODE_ENV
 
-# copy in our source code last, as it changes the most
+# Copy our source code last, as it changes the most
+USER root
 COPY --chown=appuser:appuser . .
 
 # ===================================
@@ -70,24 +74,28 @@ FROM appbase as staticbuilder
 # ===================================
 
 # Set NODE_ENV to production in the staticbuilder container
-# ARG NODE_ENV=production
-# ENV NODE_ENV $NODE_ENV
+ARG NODE_ENV=production
+ENV NODE_ENV $NODE_ENV
 
-# COPY . /app
-# RUN yarn build
+USER root
+COPY . /app
+RUN yarn build
 
-# FROM registry.access.redhat.com/ubi8/nginx-120 AS production
-# USER root
+# =================================
+FROM ${BUILDER_REGISTRY}/ubi8/nginx-120 AS production
+# =================================
 
-# RUN chgrp -R 0 /usr/share/nginx/html && \
-    # chmod -R g=u /usr/share/nginx/html
+USER root
+
+RUN chgrp -R 0 /usr/share/nginx/html && \
+    chmod -R g=u /usr/share/nginx/html
 
 # Copy static build
-# COPY --from=staticbuilder /app/build /usr/share/nginx/html
+COPY --from=staticbuilder /app/build /usr/share/nginx/html
 
 # Copy nginx config
-# COPY /etc/nginx.conf  /etc/nginx/
+COPY /etc/nginx.conf /etc/nginx/
 
-# EXPOSE 8080
+EXPOSE 8080
 
-# CMD ["nginx", "-g", "daemon off;"]
+CMD ["nginx", "-g", "daemon off;"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,7 @@
-FROM node:18-slim AS appbase
+# Should override BUILDER_REGISTRY in the pipeline build-config environment variable section.
+# Red Hat registry is used as a reasonably reliable backup.
+ARG BUILDER_REGISTRY=registry.access.redhat.com
+FROM ${BUILDER_REGISTRY}/ubi9/nodejs-18-minimal AS appbase
 
 COPY tools /tools
 COPY scripts /scripts
@@ -8,11 +11,11 @@ ENV PATH="/scripts:${PATH}"
 # Make bash the only shell
 RUN ["chmod", "+x", "/scripts/base_setup.sh"]
 RUN ["chmod", "+x", "/scripts/setup_bash.sh"]
-RUN ["chmod", "+x", "/scripts/setup_apt_packages.sh"]
+RUN ["chmod", "+x", "/scripts/setup_dnf_packages.sh"]
 RUN ["chmod", "+x", "/scripts/setup_user.sh"]
 RUN ["chmod", "+x", "/scripts/setup_app_folder.sh"]
-RUN ["chmod", "+x", "/tools/apt-install.sh"]
-RUN ["chmod", "+x", "/tools/apt-cleanup.sh"]
+RUN ["chmod", "+x", "/tools/dnf-install.sh"]
+RUN ["chmod", "+x", "/tools/dnf-cleanup.sh"]
 RUN /scripts/base_setup.sh
 
 WORKDIR /app
@@ -42,14 +45,14 @@ COPY package.json yarn.lock ./
 ENV PATH /app/node_modules/.bin:$PATH
 
 USER root
-RUN bash /tools/apt-install.sh build-essential
+RUN bash /tools/dnf-install.sh build-essential
 
 USER appuser
 RUN yarn config set network-timeout 300000
 RUN yarn && yarn cache clean --force
 
 USER root
-RUN bash /tools/apt-cleanup.sh build-essential
+RUN bash /tools/dnf-cleanup.sh build-essential
 
 # =============================
 FROM appbase as development
@@ -67,24 +70,24 @@ FROM appbase as staticbuilder
 # ===================================
 
 # Set NODE_ENV to production in the staticbuilder container
-ARG NODE_ENV=production
-ENV NODE_ENV $NODE_ENV
+# ARG NODE_ENV=production
+# ENV NODE_ENV $NODE_ENV
 
-COPY . /app
-RUN yarn build
+# COPY . /app
+# RUN yarn build
 
-FROM registry.access.redhat.com/ubi8/nginx-120 AS production
-USER root
+# FROM registry.access.redhat.com/ubi8/nginx-120 AS production
+# USER root
 
-RUN chgrp -R 0 /usr/share/nginx/html && \
-    chmod -R g=u /usr/share/nginx/html
+# RUN chgrp -R 0 /usr/share/nginx/html && \
+    # chmod -R g=u /usr/share/nginx/html
 
 # Copy static build
-COPY --from=staticbuilder /app/build /usr/share/nginx/html
+# COPY --from=staticbuilder /app/build /usr/share/nginx/html
 
 # Copy nginx config
-COPY /etc/nginx.conf  /etc/nginx/
+# COPY /etc/nginx.conf  /etc/nginx/
 
-EXPOSE 8080
+# EXPOSE 8080
 
-CMD ["nginx", "-g", "daemon off;"]
+# CMD ["nginx", "-g", "daemon off;"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -82,7 +82,7 @@ COPY . /app
 RUN yarn build
 
 # =================================
-FROM ${BUILDER_REGISTRY}/ubi8/nginx-120 AS production
+FROM ${BUILDER_REGISTRY}/ubi9/nginx-124 AS production
 # =================================
 
 USER root

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,7 +27,7 @@ RUN chmod +x /scripts/base_setup.sh && \
 
 WORKDIR /app
 
-ENV NPM_CONFIG_LOGLEVEL warn
+ENV NPM_CONFIG_LOGLEVEL=warn
 
 # Set node environment, either development or production
 # Use development to install devDependencies
@@ -58,7 +58,7 @@ RUN yarn config set network-timeout 300000 && \
     yarn cache clean --force
 
 # =============================
-FROM appbase as development
+FROM appbase AS development
 # =============================
 
 # Set NODE_ENV to development in the development container
@@ -70,7 +70,7 @@ USER root
 COPY --chown=appuser:appuser . .
 
 # ===================================
-FROM appbase as staticbuilder
+FROM appbase AS staticbuilder
 # ===================================
 
 # Set NODE_ENV to production in the staticbuilder container

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -13,11 +13,11 @@ USER root
 RUN adduser -u 5000 devuser
 
 # Provide some necessary permissions for the non-root user
-RUN chown -R devuser:devuser /app
+RUN chown -R devuser:devuser /app /opt/app-root
 
 # Install yarn
 RUN curl --silent --location https://dl.yarnpkg.com/rpm/yarn.repo | tee /etc/yum.repos.d/yarn.repo && \
-    microdnf install yarn -y && \
+    microdnf install yarn git -y && \
     microdnf clean all
 
 # Assume non-root user for rest of the operations, including running the app.
@@ -34,4 +34,4 @@ COPY --chown=devuser:devuser . .
 
 EXPOSE 4000
 
-CMD yarn start
+CMD ["yarn", "start"]

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,19 +1,37 @@
-FROM node:18-alpine
+FROM registry.access.redhat.com/ubi9/nodejs-18-minimal
 
 WORKDIR /app
 
 COPY package.json yarn.lock ./
 
 RUN node --version
-RUN apk update
-RUN apk add python3
-RUN yarn install && yarn cache clean --force
-RUN mkdir node_modules/.cache && chmod -R 777 node_modules/.cache
 
-COPY . .
+# Assume root for initial actions that require privileges
+USER root
+
+# Create a non-root user for non-privileged uses
+RUN adduser --system appuser
+
+# Install software
+RUN chown -R appuser:appuser /var/cache/yum /app /opt/app-root
+RUN microdnf update --setopt=cachedir=/tmp/yum-cache && \
+    microdnf install python3 -y --setopt install_weak_deps=0 && \
+    microdnf clean all
+RUN npm install yarn -g
+
+# Assume the non-root user
+USER appuser
+
+# Build the dependencies
+RUN yarn install && yarn cache clean --force
+RUN mkdir node_modules/.cache && chown -R appuser:appuser node_modules
+
+COPY --chown=appuser:appuser . .
 
 # RUN yarn prepare-renew-endpoint
 
 VOLUME [ "/app" ]
 
 CMD ["yarn", "start"]
+
+# TODO this completes but Vite doesn't have permissions to node_modules

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -9,29 +9,25 @@ RUN node --version
 # Assume root for initial actions that require privileges
 USER root
 
-# Create a non-root user for non-privileged uses
-RUN adduser --system appuser
+# Best practice for non-root users is to start the ID from 5000
+RUN adduser -u 5000 devuser
 
-# Install software
-RUN chown -R appuser:appuser /var/cache/yum /app /opt/app-root
-RUN microdnf update --setopt=cachedir=/tmp/yum-cache && \
-    microdnf install python3 -y --setopt install_weak_deps=0 && \
+# Install software, and provide necessary permissions for the non-root user
+RUN chown -R devuser:devuser /app && \
+    chmod -R 755 /app && \
+    curl --silent --location https://dl.yarnpkg.com/rpm/yarn.repo | tee /etc/yum.repos.d/yarn.repo && \
+    microdnf install yarn -y && \
     microdnf clean all
-RUN npm install yarn -g
 
-# Assume the non-root user
-USER appuser
+# Assume non-root user for rest of the operations, including running the app
+USER devuser
 
 # Build the dependencies
-RUN yarn install && yarn cache clean --force
-RUN mkdir node_modules/.cache && chown -R appuser:appuser node_modules
+RUN yarn && \
+    yarn cache clean --force
 
-COPY --chown=appuser:appuser . .
+COPY --chown=devuser:devuser . .
 
 # RUN yarn prepare-renew-endpoint
 
-VOLUME [ "/app" ]
-
-CMD ["yarn", "start"]
-
-# TODO this completes but Vite doesn't have permissions to node_modules
+CMD yarn start

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -9,23 +9,25 @@ RUN node --version
 # Assume root for initial actions that require privileges
 USER root
 
-# Best practice for non-root users is to start the ID from 5000
+# Add a non-root user. Best practice for non-root users is to start the ID from 5000.
 RUN adduser -u 5000 devuser
 
-# Install software, and provide necessary permissions for the non-root user
-RUN chown -R devuser:devuser /app && \
-    chmod -R 755 /app && \
-    curl --silent --location https://dl.yarnpkg.com/rpm/yarn.repo | tee /etc/yum.repos.d/yarn.repo && \
+# Provide some necessary permissions for the non-root user
+RUN chown -R devuser:devuser /app
+
+# Install yarn
+RUN curl --silent --location https://dl.yarnpkg.com/rpm/yarn.repo | tee /etc/yum.repos.d/yarn.repo && \
     microdnf install yarn -y && \
     microdnf clean all
 
-# Assume non-root user for rest of the operations, including running the app
+# Assume non-root user for rest of the operations, including running the app.
 USER devuser
 
 # Build the dependencies
 RUN yarn && \
     yarn cache clean --force
 
+# Copy over the rest of the built files, making sure the non-root user has access.
 COPY --chown=devuser:devuser . .
 
 # RUN yarn prepare-renew-endpoint

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -30,4 +30,6 @@ COPY --chown=devuser:devuser . .
 
 # RUN yarn prepare-renew-endpoint
 
+EXPOSE 4000
+
 CMD yarn start

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,4 +1,6 @@
+# =============================
 FROM registry.access.redhat.com/ubi9/nodejs-18-minimal
+# =============================
 
 WORKDIR /app
 
@@ -15,7 +17,7 @@ RUN adduser -u 5000 devuser
 # Provide some necessary permissions for the non-root user
 RUN chown -R devuser:devuser /app /opt/app-root
 
-# Install yarn
+# Install necessary build tools
 RUN curl --silent --location https://dl.yarnpkg.com/rpm/yarn.repo | tee /etc/yum.repos.d/yarn.repo && \
     microdnf install yarn git -y && \
     microdnf clean all
@@ -30,6 +32,7 @@ RUN yarn && \
 # Copy over the rest of the built files, making sure the non-root user has access.
 COPY --chown=devuser:devuser . .
 
+# Uncomment the next line if you need to run the related script
 # RUN yarn prepare-renew-endpoint
 
 EXPOSE 4000

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,4 @@
 # This file is for running a local development container
-version: '3'
 services:
     app:
         build:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,4 +10,4 @@ services:
             -   ./src:/app/src
         ports:
             - "4000:4000"
-        container_name: mvj-ui-public
+        container_name: mvj-ui-public-dev

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,5 +10,5 @@ services:
         volumes:
             -   ./src:/app/src
         ports:
-            - "3000:3000"
+            - "4000:4000"
         container_name: mvj-ui-public

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,3 +1,4 @@
+# This definition is for running a development container
 version: '3'
 services:
     app:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-# This definition is for running a development container
+# This file is for running a local development container
 version: '3'
 services:
     app:

--- a/scripts/base_setup.sh
+++ b/scripts/base_setup.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-scripts/setup_bash.sh
-scripts/setup_dnf_packages.sh
-scripts/setup_user.sh
-scripts/setup_app_folder.sh
+/scripts/setup_bash.sh
+/scripts/setup_dnf_packages.sh
+/scripts/setup_user.sh
+/scripts/setup_app_folder.sh

--- a/scripts/base_setup.sh
+++ b/scripts/base_setup.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
 scripts/setup_bash.sh
-scripts/setup_apt_packages.sh
+scripts/setup_dnf_packages.sh
 scripts/setup_user.sh
 scripts/setup_app_folder.sh

--- a/scripts/setup_apt_packages.sh
+++ b/scripts/setup_apt_packages.sh
@@ -1,9 +1,0 @@
-#!/bin/bash
-
-apt-get update
-apt-get upgrade -y
-# Install convenience packages
-/tools/apt-install.sh \
- git \
- curl
-/tools/apt-cleanup.sh

--- a/scripts/setup_dnf_packages.sh
+++ b/scripts/setup_dnf_packages.sh
@@ -1,8 +1,6 @@
 #!/bin/bash
 
+# Install necessary packages to get started
 microdnf -y upgrade
-
-# Install convenience packages
-/tools/dnf-install.sh \
- yarn
+/tools/dnf-install.sh yarn
 /tools/dnf-cleanup.sh

--- a/scripts/setup_dnf_packages.sh
+++ b/scripts/setup_dnf_packages.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+microdnf -y upgrade
+
+# Install convenience packages
+/tools/dnf-install.sh \
+ git \
+ curl
+/tools/dnf-cleanup.sh

--- a/scripts/setup_dnf_packages.sh
+++ b/scripts/setup_dnf_packages.sh
@@ -4,6 +4,5 @@ microdnf -y upgrade
 
 # Install convenience packages
 /tools/dnf-install.sh \
- git \
- curl
+ yarn
 /tools/dnf-cleanup.sh

--- a/scripts/setup_user.sh
+++ b/scripts/setup_user.sh
@@ -1,19 +1,19 @@
 #!/bin/bash
 
-existing_group=$(getent group 1000 | cut -d: -f1)
+existing_group=$(getent group 5000 | cut -d: -f1)
 if [[ -z "${existing_group}" ]]; then
     # Create appuser group
-   groupadd --gid 1000 appuser
+   groupadd --gid 5000 appuser
 elif [[ "${existing_group}" != "appuser" ]]; then
    # Change group name to appuser
    groupmod -n appuser "${existing_group}"
 fi
 
 
-existing_user=$(id -nu 1000 2>/dev/null)
+existing_user=$(id -nu 5000 2>/dev/null)
 if [[ -z "${existing_user}" ]]; then
     # Add an application user
-    useradd --uid 1000 --gid appuser --create-home --shell /bin/bash appuser
+    useradd --uid 5000 --gid appuser --create-home --shell /bin/bash appuser
 else
     # Change user name to appuser
     usermod -l appuser "${existing_user}"

--- a/scripts/setup_user.sh
+++ b/scripts/setup_user.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+# Creates a non-root user and group. IDs start from 5000 as recommended by Red Hat.
+
 existing_group=$(getent group 5000 | cut -d: -f1)
 if [[ -z "${existing_group}" ]]; then
     # Create appuser group

--- a/tools/apt-cleanup.sh
+++ b/tools/apt-cleanup.sh
@@ -1,9 +1,0 @@
-#!/bin/bash
-
-if [[ ! -z "$@" ]]; then
-    apt-get remove -y "$@"
-fi
-
-apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false
-rm -rf /var/lib/apt/lists/*
-rm -rf /var/cache/apt/archives

--- a/tools/apt-install.sh
+++ b/tools/apt-install.sh
@@ -1,4 +1,0 @@
-#!/bin/bash
-
-apt-get update
-apt-get install -y --no-install-recommends "$@"

--- a/tools/dnf-cleanup.sh
+++ b/tools/dnf-cleanup.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+if [[ ! -z "$@" ]]; then
+    microdnf remove -y "$@"
+fi
+
+microdnf clean all

--- a/tools/dnf-install.sh
+++ b/tools/dnf-install.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-microdnf install -y --setopt=install_weak_deps=0 --nodocs --setopt=cachedir=/tmp/yum-cache "$@"
+microdnf install -y --setopt=install_weak_deps=0 --nodocs "$@"

--- a/tools/dnf-install.sh
+++ b/tools/dnf-install.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+microdnf install -y --setopt=install_weak_deps=0 --nodocs --setopt=cachedir=/tmp/yum-cache "$@"

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -46,7 +46,7 @@ export default defineConfig({
   },
   envDir: './',
   server: {
-    host: 'localhost',
+    host: '0.0.0.0',
     port: 4000,
     origin: 'http://localhost:4000'
   }


### PR DESCRIPTION
Use Red Hat UBI images to avoid Docker Hub pull rate limits. The new `minimal` images use `microdnf` package manager instead of `apt`. The full image would use `dnf`, but I thought the minimal image, like the previous `slim` image, would be more economic for CI use.