### PR TITLE
Mvj 683 header href

### DIFF
--- a/src/i18n/en/common.json
+++ b/src/i18n/en/common.json
@@ -603,6 +603,12 @@
       "areaSearch": "Area rental",
       "otherCompetitionsAndSearches": "Other bids and rentals",
       "plotSearchAndCompetitions": "Plot rentals and bids"
+    },
+    "externalLinks": {
+      "helsinki": {
+        "label": "City of Helsinki",
+        "href": "https://www.hel.fi/en"
+      }
     }
   },
   "validation": {

--- a/src/i18n/en/common.json
+++ b/src/i18n/en/common.json
@@ -607,7 +607,8 @@
     "externalLinks": {
       "helsinki": {
         "label": "City of Helsinki",
-        "href": "https://www.hel.fi/en"
+        "href": "https://www.hel.fi/en",
+        "openInExternalDomainAriaLabel": "Opens a different website."
       }
     }
   },

--- a/src/i18n/fi/common.json
+++ b/src/i18n/fi/common.json
@@ -602,6 +602,12 @@
       "areaSearch": "Aluehaku",
       "otherCompetitionsAndSearches": "Muut kilpailut ja haut",
       "plotSearchAndCompetitions": "Tonttihaut ja -kilpailut"
+    },
+    "externalLinks": {
+      "helsinki": {
+        "label": "Helsingin kaupunki",
+        "href": "https://www.hel.fi/fi"
+      }
     }
   },
   "validation": {

--- a/src/i18n/fi/common.json
+++ b/src/i18n/fi/common.json
@@ -606,7 +606,8 @@
     "externalLinks": {
       "helsinki": {
         "label": "Helsingin kaupunki",
-        "href": "https://www.hel.fi/fi"
+        "href": "https://www.hel.fi/fi",
+        "openInExternalDomainAriaLabel": "Siirtyy toiseen sivustoon."
       }
     }
   },

--- a/src/i18n/fi/common.json
+++ b/src/i18n/fi/common.json
@@ -362,7 +362,7 @@
     },
     "bannerText": "Helsingin kaupungin tonttien sekä maa- ja vesialueiden vuokraus ja myynti",
     "contentHeader": "Miten voimme auttaa vuokraustarpeissasi?",
-    "label": "Front page",
+    "label": "Etusivu",
     "otherCompetitionsAndSearches": {
       "counter_one": "Muut kilpailut ja haut: {{count}} kpl",
       "counter_other": "Muut kilpailut ja haut: {{count}} kpl",

--- a/src/i18n/sv/common.json
+++ b/src/i18n/sv/common.json
@@ -607,7 +607,8 @@
     "externalLinks": {
       "helsinki": {
         "label": "Helsingfors stad",
-        "href": "https://www.hel.fi/sv"
+        "href": "https://www.hel.fi/sv",
+        "openInExternalDomainAriaLabel": "Länk leder till extern tjänst."
       }
     }
   },

--- a/src/i18n/sv/common.json
+++ b/src/i18n/sv/common.json
@@ -603,6 +603,12 @@
       "areaSearch": "Områdesökning",
       "otherCompetitionsAndSearches": "Andra tävlingar och sökningar",
       "plotSearchAndCompetitions": "Plot sökningar och tävlingar"
+    },
+    "externalLinks": {
+      "helsinki": {
+        "label": "Helsingfors stad",
+        "href": "https://www.hel.fi/sv"
+      }
     }
   },
   "validation": {

--- a/src/i18n/sv/common.json
+++ b/src/i18n/sv/common.json
@@ -363,7 +363,7 @@
     },
     "bannerText": "Uthyrning och försäljning av tomter, mark- och vattenområden av Helsingfors stad",
     "contentHeader": "Hur kan vi hjälpa till med dina hyresbehov?",
-    "label": "Front page",
+    "label": "Huvudsida",
     "otherCompetitionsAndSearches": {
       "counter_one": "Andra tävlingar och sökningar: {{count}}",
       "counter_other": "Andra tävlingar och sökningar: {{count}}",

--- a/src/topNavigation/topNavigation.tsx
+++ b/src/topNavigation/topNavigation.tsx
@@ -1,10 +1,11 @@
-import { Link, useNavigate } from 'react-router-dom';
+import { Link as RouterLink, useNavigate } from 'react-router-dom';
 import { connect } from 'react-redux';
 import {
   Header,
   IconSignout,
   IconUser,
   LanguageOption,
+  Link,
   Logo,
   logoFi,
 } from 'hds-react';
@@ -71,7 +72,7 @@ const TopNavigationLink = ({
   return (
     <Header.Link
       label={label}
-      as={Link}
+      as={RouterLink}
       to={to}
       active={match !== null}
       className={className}
@@ -185,6 +186,13 @@ const TopNavigation = ({
             label={t(link.label, link.default || '')}
           />
         ))}
+        <Header.Link
+          as={Link}
+          label={t('topNavigation.externalLinks.helsinki.label')}
+          href={t('topNavigation.externalLinks.helsinki.href')}
+          external
+          children={null}
+        />
       </Header.NavigationMenu>
     </Header>
   );

--- a/src/topNavigation/topNavigation.tsx
+++ b/src/topNavigation/topNavigation.tsx
@@ -191,6 +191,10 @@ const TopNavigation = ({
           label={t('topNavigation.externalLinks.helsinki.label')}
           href={t('topNavigation.externalLinks.helsinki.href')}
           external
+          openInExternalDomainAriaLabel={t(
+            'topNavigation.externalLinks.helsinki.openInExternalDomainAriaLabel',
+            'Avautuu uudessa välilehdessä.',
+          )}
           children={null}
         />
       </Header.NavigationMenu>


### PR DESCRIPTION
hds-react either does not automatically translate the aria-label, or our translation does not trigger that in hds-react components.
Done it manually for now.