### PR TITLE
MVJ-728 Data protection notices

### DIFF
--- a/src/areaSearch/areaSearchApplicationPage.tsx
+++ b/src/areaSearch/areaSearchApplicationPage.tsx
@@ -17,6 +17,7 @@ import AreaSearchTargetSummary from './components/areaSearchTargetSummary';
 import ApplicationForm from './components/applicationForm';
 import ScrollToTop from '../common/ScrollToTop';
 import ApplicationErrorsSummary from '../application/components/ApplicationErrorsSummary';
+import DataProtectionNotices from './components/dataProtectionNotices';
 import {
   AreaSearchStepperPageIndex,
   getInitialAreaSearchApplicationForm,
@@ -87,6 +88,7 @@ const AreaSearchApplicationPage = ({
               formName={AREA_SEARCH_FORM_NAME}
               baseForm={lastSubmission.form}
             />
+            <DataProtectionNotices />
             <Row className="ApplicationPage__notifications">
               <Col xs={12}>
                 <ApplicationErrorsSummary

--- a/src/areaSearch/components/_dataProtectionNotices.scss
+++ b/src/areaSearch/components/_dataProtectionNotices.scss
@@ -1,0 +1,5 @@
+.DataProtectionNotices {
+  .DataProtectionNotices__link-row {
+    margin-bottom: 1em;
+  }
+}

--- a/src/areaSearch/components/dataProtectionNotices.tsx
+++ b/src/areaSearch/components/dataProtectionNotices.tsx
@@ -1,0 +1,83 @@
+import { Link, IconLinkExternal } from 'hds-react';
+import { Col, Row } from 'react-grid-system';
+import { useTranslation } from 'react-i18next';
+
+const DataProtectionNotices = (): JSX.Element => {
+  const { t } = useTranslation();
+
+  return (
+    <div className="DataProtectionNotices">
+      <h3>
+        {t('areaSearch.dataProtectionNotices.title', 'Tietosuojaselosteet')}
+      </h3>
+      <Row className="DataProtectionNotices__link-row">
+        <Col>
+          <Link
+            href={t(
+              'areaSearch.dataProtectionNotices.tontit.externalUrl',
+              'https://www.hel.fi/static/liitteet-2019/Kaupunginkanslia/Rekisteriselosteet/Kymp/Tonttien%20hankinnan%20ja%20luovutuksen%20asiakasrekisteri.pdf',
+            )}
+            target="_blank"
+            size="M"
+            aria-label={t(
+              'areaSearch.dataProtectionNotices.tontit.ariaLabel',
+              'Data protection notice for Tonttien hankinnan ja luovutuksen asiakasrekisteri. Opens a different website in a new tab',
+            )}
+          >
+            {t(
+              'areaSearch.dataProtectionNotices.tontit.linkText',
+              'Helsingin kaupungin tonttien hankinnan ja luovutuksen asiakasrekisteri',
+            )}{' '}
+            <IconLinkExternal />
+          </Link>
+        </Col>
+      </Row>
+      <Row className="DataProtectionNotices__link-row">
+        <Col>
+          <Link
+            href={t(
+              'areaSearch.dataProtectionNotices.alueet.externalUrl',
+              'https://www.hel.fi/static/liitteet-2019/Kaupunginkanslia/Rekisteriselosteet/Kymp/Alueiden%20käytön%20lupa-%20ja%20vuokrausasioiden%20asiakasrekisteri.pdf',
+            )}
+            target="_blank"
+            size="M"
+            aria-label={t(
+              'areaSearch.dataProtectionNotices.alueet.ariaLabel',
+              'Data protection notice for Alueiden käytön lupa- ja vuokrausasioiden asiakasrekisteri. Opens a different website in a new tab',
+            )}
+          >
+            {t(
+              'areaSearch.dataProtectionNotices.alueet.linkText',
+              'Alueiden käytön lupa- ja vuokrausasioiden asiakasrekisteri',
+            )}{' '}
+            <IconLinkExternal />
+          </Link>
+        </Col>
+      </Row>
+      <Row className="DataProtectionNotices__link-row">
+        <Col>
+          <Link
+            href={t(
+              'areaSearch.dataProtectionNotices.liikuntapalvelut.externalUrl',
+              'https://www.hel.fi/static/liitteet-2019/Kaupunginkanslia/Rekisteriselosteet/Kuva/Liikuntapalvelujen%20vuokrauksenhallintarekisteri.pdf',
+            )}
+            target="_blank"
+            size="M"
+            aria-label={t(
+              'areaSearch.dataProtectionNotices.liikuntapalvelut.ariaLabel',
+              'Data protection notice for Liikuntapalvelujen vuokrauksenhallintarekisteri. Opens a different website in a new tab',
+            )}
+          >
+            {t(
+              'areaSearch.dataProtectionNotices.liikuntapalvelut.linkText',
+              'Liikuntapalvelujen vuokrauksenhallintarekisteri',
+            )}{' '}
+            <IconLinkExternal />
+          </Link>
+        </Col>
+      </Row>
+    </div>
+  );
+};
+
+export default DataProtectionNotices;

--- a/src/i18n/en/common.json
+++ b/src/i18n/en/common.json
@@ -190,24 +190,24 @@
     "specs": {
       "area": {
         "areaDescription": "Detailed area description",
-        "areaDescriptionHelpText": "Vuokra-alue mahdollisimman tarkasti määriteltynä.",
+        "areaDescriptionHelpText": "Describe the rental area as precisely as possible.",
         "drawOnMap": {
           "explanation": "Your choice of area is the basis for the negotiation. The area you draw is for reference only. We will contact you regarding the detailed delineation during the application process.",
           "heading": "Draw the desired area on the map",
           "helpTexts": {
-            "label": "",
-            "phase1": "",
-            "phase2": "",
-            "phase3": "",
-            "phase4": "",
-            "zoomTools": "",
-            "zoomToolsAlt": "",
-            "drawTools": "",
-            "drawToolsAlt": "",
-            "editTools": "",
-            "editToolsAlt": "",
-            "mapLayers": "",
-            "mapLayersAlt": ""
+            "label": "Map tool",
+            "phase1": "Start by finding a location on the map using the address search or the zoom in and out tool.",
+            "phase2": "Draw the desired area on the map using the drawing tools. You can draw either polygonal or rectangular areas. Multiple areas can be drawn.",
+            "phase3": "The areas you draw are automatically saved on the map, and you can continue filling out the application.",
+            "phase4": "You can edit the area you have drawn by pressing the edit button. By pressing the delete button, you can remove one or multiple items.",
+            "zoomTools": "= zooming in and out",
+            "zoomToolsAlt": "Zoom in and out on the map",
+            "drawTools": "= drawing tools",
+            "drawToolsAlt": "Draw the area on the map",
+            "editTools": "= edit and delete",
+            "editToolsAlt": "Edit buttons",
+            "mapLayers": "= map layers",
+            "mapLayersAlt": "Map layers"
           }
         },
         "heading": "Tell us which area you'd like to lease"
@@ -224,7 +224,7 @@
         "other": "An unknown error occurred while saving the area rental. Please try again.",
         "startDateBeforeEndDate": "Start date cannot be after end date.",
         "validation": "Please check that the indicated fields are completed correctly.",
-        "eitherPolygonOrDescription": "Jatkaaksesi esikatseluun sinun tulee olla joko A) valinnut vuokra-alueen kartalla tai B) kuvaillut vuokra-aluetta sanallisesti."
+        "eitherPolygonOrDescription": "To proceed to the preview, you must either A) have selected the rental area on the map or B) have described the rental area verbally."
       },
       "explanation": "If you want to lease an area, continue by completing the application form. Tell us which area you require, your intended use, and the lease time. We will contact you as soon as possible. Fields marked with an asterisk are required. ",
       "heading": "1. Area selection",
@@ -236,7 +236,7 @@
         "mainType": "Intended use",
         "mainTypePlaceholder": "Choose intended use",
         "projectDescription": "Detailed description of the intended use",
-        "projectDescriptionHelpText": "Minkälaista toimintaa vuokrakohteessa on tarkoitus järjestää? Minkälaisia rakenteita vuokra-alueelle on tulossa? Kuvaile, ketkä käyttävät aluetta? Onko kyseessä jatkohakemus voimassa olevalle vuokraukselle (jos on, ilmoita vuokraustunnus)?",
+        "projectDescriptionHelpText": "What kind of activities are planned for the rental property? What kind of structures are going to be built in the rental area? Describe who will be using the area. Is this an application for an extension of an existing rental agreement (if so, please provide the rental ID)?",
         "startDate": "Start date for lease",
         "startDateHelpText": "Press Select to choose a date from the calendar. Please note that applications are processed on a first come, first served basis."
       },

--- a/src/i18n/en/common.json
+++ b/src/i18n/en/common.json
@@ -250,6 +250,24 @@
         "hide": "Hide target details",
         "show": "Show target details"
       }
+    },
+    "dataProtectionNotices": {
+      "title": "Data protection notices",
+      "tontit": {
+        "externalUrl": "https://www.hel.fi/static/liitteet-2019/Kaupunginkanslia/Rekisteriselosteet/Kymp/Tonttien%20hankinnan%20ja%20luovutuksen%20asiakasrekisteri.pdf",
+        "ariaLabel": "Data protection notice for Tonttien hankinnan ja luovutuksen asiakasrekisteri. Opens a different website in a new tab",
+        "linkText": ""
+      },
+      "alueet": {
+        "externalUrl": "https://www.hel.fi/static/liitteet-2019/Kaupunginkanslia/Rekisteriselosteet/Kymp/Alueiden%20k%C3%A4yt%C3%B6n%20lupa-%20ja%20vuokrausasioiden%20asiakasrekisteri.pdf",
+        "ariaLabel": "Data protection notice for Alueiden käytön lupa- ja vuokrausasioiden asiakasrekisteri. Opens a different website in a new tab",
+        "linkText": ""
+      },
+      "liikuntapalvelut": {
+        "externalUrl": "https://www.hel.fi/static/liitteet-2019/Kaupunginkanslia/Rekisteriselosteet/Kuva/Liikuntapalvelujen%20vuokrauksenhallintarekisteri.pdf",
+        "ariaLabel": "Data protection notice for Liikuntapalvelujen vuokrauksenhallintarekisteri. Opens a different website in a new tab",
+        "linkText": ""
+      }
     }
   },
   "components": {

--- a/src/i18n/fi/common.json
+++ b/src/i18n/fi/common.json
@@ -250,6 +250,24 @@
         "hide": "Piilota kohteen tarkemmat tiedot",
         "show": "Näytä kohteen tarkemmat tiedot"
       }
+    },
+    "dataProtectionNotices": {
+      "title": "Tietosuojaselosteet",
+      "tontit": {
+        "externalUrl": "https://www.hel.fi/static/liitteet-2019/Kaupunginkanslia/Rekisteriselosteet/Kymp/Tonttien%20hankinnan%20ja%20luovutuksen%20asiakasrekisteri.pdf",
+        "ariaLabel": "Helsingin kaupungin tonttien hankinnan ja luovutuksen asiakasrekisterin tietosuojaseloste. Avaa ulkoisen sivun uuteen välilehteen",
+        "linkText": "Helsingin kaupungin tonttien hankinnan ja luovutuksen asiakasrekisteri"
+      },
+      "alueet": {
+        "externalUrl": "https://www.hel.fi/static/liitteet-2019/Kaupunginkanslia/Rekisteriselosteet/Kymp/Alueiden%20k%C3%A4yt%C3%B6n%20lupa-%20ja%20vuokrausasioiden%20asiakasrekisteri.pdf",
+        "ariaLabel": "Alueiden käytön lupa- ja vuokrausasioiden asiakasrekisterin tietosuojaseloste. Avaa ulkoisen sivun uuteen välilehteen",
+        "linkText": "Alueiden käytön lupa- ja vuokrausasioiden asiakasrekisteri"
+      },
+      "liikuntapalvelut": {
+        "externalUrl": "https://www.hel.fi/static/liitteet-2019/Kaupunginkanslia/Rekisteriselosteet/Kuva/Liikuntapalvelujen%20vuokrauksenhallintarekisteri.pdf",
+        "ariaLabel": "Liikuntapalvelujen vuokrauksenhallintarekisterin tietosuojaseloste. Avaa ulkoisen sivun uuteen välilehteen",
+        "linkText": "Liikuntapalvelujen vuokrauksenhallintarekisteri"
+      }
     }
   },
   "components": {

--- a/src/i18n/sv/common.json
+++ b/src/i18n/sv/common.json
@@ -46,7 +46,7 @@
         "nonOkResponse": "Sändning av bilagan misslyckades! Vänligen försök igen senare."
       },
       "filename": "Fil",
-      "info": "Den största tillåtna filstorleken är {{maxSize}} Mt.",
+      "info": "Den största tillåtna filstorleken är {{maxSize}} MB",
       "newFile": "Lägg till en fil",
       "noFilesUploaded": "Inga filer har lagts till.",
       "number": "Bilaga",
@@ -375,8 +375,8 @@
       "externalUrl": "https://www.hel.fi/sv/stadsmiljo-och-trafik/tomter-och-bygglov/tomtansokning"
     },
     "plotSearchAndCompetitions": {
-      "counter_one": "Plot sökningar och tävlingar: {{count}}",
-      "counter_other": "Plot sökningar och tävlingar: {{count}}",
+      "counter_one": "Plot sökningar och tävlingar: {{count}} st",
+      "counter_other": "Plot sökningar och tävlingar: {{count}} st",
       "counterFailed": "Tomtansökningar och -tävlingar",
       "explanation": "Tomter för långtidsbostäder eller industriell verksamhet",
       "label": "Jag vill delta i en tomtsökning eller tävling",

--- a/src/i18n/sv/common.json
+++ b/src/i18n/sv/common.json
@@ -250,6 +250,24 @@
         "hide": "Dölj närmare uppgifter om objektet",
         "show": "Visa närmare uppgifter om objektet"
       }
+    },
+    "dataProtectionNotices": {
+      "title": "Integritetspolicyer",
+      "tontit": {
+        "externalUrl": "https://www.hel.fi/static/liitteet-2019/Kaupunginkanslia/Rekisteriselosteet/Kymp/Kundregister%20f%C3%B6r%20anskaffning%20och%20%C3%B6verl%C3%A5telse%20av%20tomter.pdf",
+        "ariaLabel": "Integritetspolicy för Helsingfors stads kundregister för anskaffning och överlåtelse av tomter. Öppnar en annan webbplats i en ny flik",
+        "linkText": "Helsingfors stads kundregister för anskaffning och överlåtelse av tomter"
+      },
+      "alueet": {
+        "externalUrl": "https://www.hel.fi/static/liitteet-2019/Kaupunginkanslia/Rekisteriselosteet/Kymp/Kundregister%20f%C3%B6r%20tillst%C3%A5nds-%20och%20uthyrnings%C3%A4renden%20inom%20omr%C3%A5desanv%C3%A4ndning.pdf",
+        "ariaLabel": "Integritetspolicy för Kundregister för tillstånds- och uthyrningsärenden inom områdesanvändning. Öppnar en annan webbplats i en ny flik",
+        "linkText": "Kundregister för tillstånds- och uthyrningsärenden inom områdesanvändning"
+      },
+      "liikuntapalvelut": {
+        "externalUrl": "https://www.hel.fi/static/liitteet-2019/Kaupunginkanslia/Rekisteriselosteet/Kuva/Idrottstj%C3%A4nsternas%20hyresf%C3%B6rvaltningsregister.pdf",
+        "ariaLabel": "integritetspolicy för Idrottstjänsternas hyresförvaltningsregister. Öppnar en annan webbplats i en ny flik",
+        "linkText": "Idrottstjänsternas hyresförvaltningsregister"
+      }
     }
   },
   "components": {

--- a/src/main.scss
+++ b/src/main.scss
@@ -55,6 +55,7 @@
 @import 'areaSearch/components/areaSearchTargetSummary';
 @import 'areaSearch/components/areaSearchTargetSummaryMap';
 @import 'areaSearch/components/areaSearchTargetSummaryInfo';
+@import 'areaSearch/components/dataProtectionNotices';
 @import 'boxGrid/boxGrid';
 @import 'boxGrid/boxGridBox';
 @import 'directReservation/directReservationPage';


### PR DESCRIPTION
Adds a new component to area search page two: links to data protection notices. The form itself will be localized as part of another ticket.

Additionally, minor fixes to english and swedish translations elsewhere

Screenshot of Finnish localisation:

![image](https://github.com/user-attachments/assets/0fe8f3f3-2a4d-455d-a259-ad6c33342bcf)

