### PR TITLE
Area search data protection notices - Use HDS-native properties

### DIFF
--- a/src/areaSearch/components/dataProtectionNotices.tsx
+++ b/src/areaSearch/components/dataProtectionNotices.tsx
@@ -1,4 +1,4 @@
-import { Link, IconLinkExternal } from 'hds-react';
+import { Link } from 'hds-react';
 import { Col, Row } from 'react-grid-system';
 import { useTranslation } from 'react-i18next';
 
@@ -17,18 +17,22 @@ const DataProtectionNotices = (): JSX.Element => {
               'areaSearch.dataProtectionNotices.tontit.externalUrl',
               'https://www.hel.fi/static/liitteet-2019/Kaupunginkanslia/Rekisteriselosteet/Kymp/Tonttien%20hankinnan%20ja%20luovutuksen%20asiakasrekisteri.pdf',
             )}
-            target="_blank"
+            external
+            openInNewTab
             size="M"
             aria-label={t(
               'areaSearch.dataProtectionNotices.tontit.ariaLabel',
-              'Data protection notice for Tonttien hankinnan ja luovutuksen asiakasrekisteri. Opens a different website in a new tab',
+              'Data protection notice for Tonttien hankinnan ja luovutuksen asiakasrekisteri.',
             )}
+            openInExternalDomainAriaLabel={t(
+              'application.ariaLabels.openInExternalDomain',
+            )}
+            openInNewTabAriaLabel={t('application.ariaLabels.openInNewTab')}
           >
             {t(
               'areaSearch.dataProtectionNotices.tontit.linkText',
               'Helsingin kaupungin tonttien hankinnan ja luovutuksen asiakasrekisteri',
-            )}{' '}
-            <IconLinkExternal />
+            )}
           </Link>
         </Col>
       </Row>
@@ -39,18 +43,22 @@ const DataProtectionNotices = (): JSX.Element => {
               'areaSearch.dataProtectionNotices.alueet.externalUrl',
               'https://www.hel.fi/static/liitteet-2019/Kaupunginkanslia/Rekisteriselosteet/Kymp/Alueiden%20käytön%20lupa-%20ja%20vuokrausasioiden%20asiakasrekisteri.pdf',
             )}
-            target="_blank"
+            external
+            openInNewTab
             size="M"
             aria-label={t(
               'areaSearch.dataProtectionNotices.alueet.ariaLabel',
-              'Data protection notice for Alueiden käytön lupa- ja vuokrausasioiden asiakasrekisteri. Opens a different website in a new tab',
+              'Data protection notice for Alueiden käytön lupa- ja vuokrausasioiden asiakasrekisteri.',
             )}
+            openInExternalDomainAriaLabel={t(
+              'application.ariaLabels.openInExternalDomain',
+            )}
+            openInNewTabAriaLabel={t('application.ariaLabels.openInNewTab')}
           >
             {t(
               'areaSearch.dataProtectionNotices.alueet.linkText',
               'Alueiden käytön lupa- ja vuokrausasioiden asiakasrekisteri',
-            )}{' '}
-            <IconLinkExternal />
+            )}
           </Link>
         </Col>
       </Row>
@@ -61,18 +69,22 @@ const DataProtectionNotices = (): JSX.Element => {
               'areaSearch.dataProtectionNotices.liikuntapalvelut.externalUrl',
               'https://www.hel.fi/static/liitteet-2019/Kaupunginkanslia/Rekisteriselosteet/Kuva/Liikuntapalvelujen%20vuokrauksenhallintarekisteri.pdf',
             )}
-            target="_blank"
+            external
+            openInNewTab
             size="M"
             aria-label={t(
               'areaSearch.dataProtectionNotices.liikuntapalvelut.ariaLabel',
-              'Data protection notice for Liikuntapalvelujen vuokrauksenhallintarekisteri. Opens a different website in a new tab',
+              'Data protection notice for Liikuntapalvelujen vuokrauksenhallintarekisteri',
             )}
+            openInExternalDomainAriaLabel={t(
+              'application.ariaLabels.openInExternalDomain',
+            )}
+            openInNewTabAriaLabel={t('application.ariaLabels.openInNewTab')}
           >
             {t(
               'areaSearch.dataProtectionNotices.liikuntapalvelut.linkText',
               'Liikuntapalvelujen vuokrauksenhallintarekisteri',
-            )}{' '}
-            <IconLinkExternal />
+            )}
           </Link>
         </Col>
       </Row>

--- a/src/i18n/en/common.json
+++ b/src/i18n/en/common.json
@@ -1,5 +1,9 @@
 {
   "application": {
+    "ariaLabels": {
+      "openInExternalDomain": "Opens a different website.",
+      "openInNewTab": "Opens in a new tab."
+    },
     "arraySection": {
       "applicantHeader": "Details of applicant {{number}}",
       "add": {
@@ -255,17 +259,17 @@
       "title": "Data protection notices",
       "tontit": {
         "externalUrl": "https://www.hel.fi/static/liitteet-2019/Kaupunginkanslia/Rekisteriselosteet/Kymp/Tonttien%20hankinnan%20ja%20luovutuksen%20asiakasrekisteri.pdf",
-        "ariaLabel": "Data protection notice for Tonttien hankinnan ja luovutuksen asiakasrekisteri. Opens a different website in a new tab",
+        "ariaLabel": "Data protection notice for Tonttien hankinnan ja luovutuksen asiakasrekisteri.",
         "linkText": ""
       },
       "alueet": {
         "externalUrl": "https://www.hel.fi/static/liitteet-2019/Kaupunginkanslia/Rekisteriselosteet/Kymp/Alueiden%20k%C3%A4yt%C3%B6n%20lupa-%20ja%20vuokrausasioiden%20asiakasrekisteri.pdf",
-        "ariaLabel": "Data protection notice for Alueiden käytön lupa- ja vuokrausasioiden asiakasrekisteri. Opens a different website in a new tab",
+        "ariaLabel": "Data protection notice for Alueiden käytön lupa- ja vuokrausasioiden asiakasrekisteri.",
         "linkText": ""
       },
       "liikuntapalvelut": {
         "externalUrl": "https://www.hel.fi/static/liitteet-2019/Kaupunginkanslia/Rekisteriselosteet/Kuva/Liikuntapalvelujen%20vuokrauksenhallintarekisteri.pdf",
-        "ariaLabel": "Data protection notice for Liikuntapalvelujen vuokrauksenhallintarekisteri. Opens a different website in a new tab",
+        "ariaLabel": "Data protection notice for Liikuntapalvelujen vuokrauksenhallintarekisteri.",
         "linkText": ""
       }
     }
@@ -629,8 +633,7 @@
     "externalLinks": {
       "helsinki": {
         "label": "City of Helsinki",
-        "href": "https://www.hel.fi/en",
-        "openInExternalDomainAriaLabel": "Opens a different website."
+        "href": "https://www.hel.fi/en"
       }
     }
   },

--- a/src/i18n/fi/common.json
+++ b/src/i18n/fi/common.json
@@ -1,5 +1,9 @@
 {
   "application": {
+    "ariaLabels": {
+      "openInExternalDomain": "Siirtyy toiseen sivustoon.",
+      "openInNewTab": "Avautuu uudessa välilehdessä."
+    },
     "arraySection": {
       "applicantHeader": "Hakijan {{number}} tiedot",
       "add": {
@@ -255,17 +259,17 @@
       "title": "Tietosuojaselosteet",
       "tontit": {
         "externalUrl": "https://www.hel.fi/static/liitteet-2019/Kaupunginkanslia/Rekisteriselosteet/Kymp/Tonttien%20hankinnan%20ja%20luovutuksen%20asiakasrekisteri.pdf",
-        "ariaLabel": "Helsingin kaupungin tonttien hankinnan ja luovutuksen asiakasrekisterin tietosuojaseloste. Avaa ulkoisen sivun uuteen välilehteen",
+        "ariaLabel": "Helsingin kaupungin tonttien hankinnan ja luovutuksen asiakasrekisterin tietosuojaseloste.",
         "linkText": "Helsingin kaupungin tonttien hankinnan ja luovutuksen asiakasrekisteri"
       },
       "alueet": {
         "externalUrl": "https://www.hel.fi/static/liitteet-2019/Kaupunginkanslia/Rekisteriselosteet/Kymp/Alueiden%20k%C3%A4yt%C3%B6n%20lupa-%20ja%20vuokrausasioiden%20asiakasrekisteri.pdf",
-        "ariaLabel": "Alueiden käytön lupa- ja vuokrausasioiden asiakasrekisterin tietosuojaseloste. Avaa ulkoisen sivun uuteen välilehteen",
+        "ariaLabel": "Alueiden käytön lupa- ja vuokrausasioiden asiakasrekisterin tietosuojaseloste.",
         "linkText": "Alueiden käytön lupa- ja vuokrausasioiden asiakasrekisteri"
       },
       "liikuntapalvelut": {
         "externalUrl": "https://www.hel.fi/static/liitteet-2019/Kaupunginkanslia/Rekisteriselosteet/Kuva/Liikuntapalvelujen%20vuokrauksenhallintarekisteri.pdf",
-        "ariaLabel": "Liikuntapalvelujen vuokrauksenhallintarekisterin tietosuojaseloste. Avaa ulkoisen sivun uuteen välilehteen",
+        "ariaLabel": "Liikuntapalvelujen vuokrauksenhallintarekisterin tietosuojaseloste.",
         "linkText": "Liikuntapalvelujen vuokrauksenhallintarekisteri"
       }
     }
@@ -629,8 +633,7 @@
     "externalLinks": {
       "helsinki": {
         "label": "Helsingin kaupunki",
-        "href": "https://www.hel.fi/fi",
-        "openInExternalDomainAriaLabel": "Siirtyy toiseen sivustoon."
+        "href": "https://www.hel.fi/fi"
       }
     }
   },

--- a/src/i18n/sv/common.json
+++ b/src/i18n/sv/common.json
@@ -1,5 +1,9 @@
 {
   "application": {
+    "ariaLabels": {
+      "openInExternalDomain": "Länk leder till extern tjänst.",
+      "openInNewTab": "Öppnas i en ny flik."
+    },
     "arraySection": {
       "applicantHeader": "Uppgifter om sökande {{number}}",
       "add": {
@@ -255,17 +259,17 @@
       "title": "Integritetspolicyer",
       "tontit": {
         "externalUrl": "https://www.hel.fi/static/liitteet-2019/Kaupunginkanslia/Rekisteriselosteet/Kymp/Kundregister%20f%C3%B6r%20anskaffning%20och%20%C3%B6verl%C3%A5telse%20av%20tomter.pdf",
-        "ariaLabel": "Integritetspolicy för Helsingfors stads kundregister för anskaffning och överlåtelse av tomter. Öppnar en annan webbplats i en ny flik",
+        "ariaLabel": "Integritetspolicy för Helsingfors stads kundregister för anskaffning och överlåtelse av tomter.",
         "linkText": "Helsingfors stads kundregister för anskaffning och överlåtelse av tomter"
       },
       "alueet": {
         "externalUrl": "https://www.hel.fi/static/liitteet-2019/Kaupunginkanslia/Rekisteriselosteet/Kymp/Kundregister%20f%C3%B6r%20tillst%C3%A5nds-%20och%20uthyrnings%C3%A4renden%20inom%20omr%C3%A5desanv%C3%A4ndning.pdf",
-        "ariaLabel": "Integritetspolicy för Kundregister för tillstånds- och uthyrningsärenden inom områdesanvändning. Öppnar en annan webbplats i en ny flik",
+        "ariaLabel": "Integritetspolicy för Kundregister för tillstånds- och uthyrningsärenden inom områdesanvändning.",
         "linkText": "Kundregister för tillstånds- och uthyrningsärenden inom områdesanvändning"
       },
       "liikuntapalvelut": {
         "externalUrl": "https://www.hel.fi/static/liitteet-2019/Kaupunginkanslia/Rekisteriselosteet/Kuva/Idrottstj%C3%A4nsternas%20hyresf%C3%B6rvaltningsregister.pdf",
-        "ariaLabel": "integritetspolicy för Idrottstjänsternas hyresförvaltningsregister. Öppnar en annan webbplats i en ny flik",
+        "ariaLabel": "integritetspolicy för Idrottstjänsternas hyresförvaltningsregister.",
         "linkText": "Idrottstjänsternas hyresförvaltningsregister"
       }
     }
@@ -629,8 +633,7 @@
     "externalLinks": {
       "helsinki": {
         "label": "Helsingfors stad",
-        "href": "https://www.hel.fi/sv",
-        "openInExternalDomainAriaLabel": "Länk leder till extern tjänst."
+        "href": "https://www.hel.fi/sv"
       }
     }
   },

--- a/src/topNavigation/topNavigation.tsx
+++ b/src/topNavigation/topNavigation.tsx
@@ -209,7 +209,7 @@ const TopNavigation = ({
           href={t('topNavigation.externalLinks.helsinki.href')}
           external
           openInExternalDomainAriaLabel={t(
-            'topNavigation.externalLinks.helsinki.openInExternalDomainAriaLabel',
+            'application.ariaLabels.openInExternalDomain',
             'Avautuu uudessa välilehdessä.',
           )}
           children={null}


### PR DESCRIPTION
This allows the design to stay consistent with HDS style guide.