### PR TITLE
Freeze lockfile for installs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,6 +20,6 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
-      - run: yarn
+      - run: yarn --frozen-lockfile
       - run: yarn build
       # - run: yarn test:coverage

--- a/.yarnrc
+++ b/.yarnrc
@@ -1,0 +1,7 @@
+# Ensures yarn.lock isn't automatically updated with `yarn` or `yarn install`.
+# Specific to Yarn v1.
+# In Yarn v2 and above, the option is called `enableImmutableInstalls` in .yarnrc.yml instead.
+# To upgrade dependencies, you'll need to use either of the following:
+#   1) yarn install --no-frozen-lockfile
+#   2) yarn upgrade <package-name>@<version>
+--frozen-lockfile true


### PR DESCRIPTION
This helps avoid accidentally installing poisoned dependencies, especially in local environments.