### PR TITLE
Revert "Bump react-router from 6.29.0 to 6.30.2"

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "react-leaflet": "^4.2.1",
     "react-leaflet-draw": "^0.20.4",
     "react-redux": "^8.1.3",
-    "react-router": "^6.30.2",
+    "react-router": "^6.29.0",
     "react-router-dom": "^6.29.0",
     "redux": "^4.2.1",
     "redux-actions": "^3.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1271,11 +1271,6 @@
   resolved "https://registry.yarnpkg.com/@remix-run/router/-/router-1.22.0.tgz#dd8096cb055c475a4de6b35322b8d3b118c17b43"
   integrity sha512-MBOl8MeOzpK0HQQQshKB7pABXbmyHizdTpqnrIseTbsv0nAepwC2ENZa1aaBExNQcpLoXmWthhak8SABLzvGPw==
 
-"@remix-run/router@1.23.1":
-  version "1.23.1"
-  resolved "https://registry.yarnpkg.com/@remix-run/router/-/router-1.23.1.tgz#0ce8857b024e24fc427585316383ad9d295b3a7f"
-  integrity sha512-vDbaOzF7yT2Qs4vO6XV1MHcJv+3dgR1sT+l3B8xxOVhUC336prMvqrvsLL/9Dnw2xr6Qhz4J0dmS0llNAbnUmQ==
-
 "@rollup/pluginutils@^5.1.3":
   version "5.1.4"
   resolved "https://registry.yarnpkg.com/@rollup/pluginutils/-/pluginutils-5.1.4.tgz#bb94f1f9eaaac944da237767cdfee6c5b2262d4a"
@@ -5388,19 +5383,12 @@ react-router-dom@^6.29.0:
     "@remix-run/router" "1.22.0"
     react-router "6.29.0"
 
-react-router@6.29.0:
+react-router@6.29.0, react-router@^6.29.0:
   version "6.29.0"
   resolved "https://registry.yarnpkg.com/react-router/-/react-router-6.29.0.tgz#14a329ca838b4de048fc5cca82874b727ee546b7"
   integrity sha512-DXZJoE0q+KyeVw75Ck6GkPxFak63C4fGqZGNijnWgzB/HzSP1ZfTlBj5COaGWwhrMQ/R8bXiq5Ooy4KG+ReyjQ==
   dependencies:
     "@remix-run/router" "1.22.0"
-
-react-router@^6.30.2:
-  version "6.30.2"
-  resolved "https://registry.yarnpkg.com/react-router/-/react-router-6.30.2.tgz#c78a3b40f7011f49a373b1df89492e7d4ec12359"
-  integrity sha512-H2Bm38Zu1bm8KUE5NVWRMzuIyAV8p/JrOaBJAwVmp37AXG72+CZJlEBw6pdn9i5TBgLMhNDgijS4ZlblpHyWTA==
-  dependencies:
-    "@remix-run/router" "1.23.1"
 
 react-side-effect@^2.1.0:
   version "2.1.2"


### PR DESCRIPTION
This reverts commit 1b0801d6758b87b31735df759135cd5b1d7bd295.

Fixes issue with useLocation in `src/login/loginModal.tsx`